### PR TITLE
Add eurlex_metadata tool and fix fetchDocument WAF issue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { randomUUID } from 'node:crypto'
 import express, { type Request, type Response } from 'express'
 import { registerSearchTool } from './tools/search.js'
 import { registerFetchTool } from './tools/fetch.js'
+import { registerMetadataTool } from './tools/metadata.js'
 import { registerGuidePrompt } from './prompts/guide.js'
 
 // ---------------------------------------------------------------------------
@@ -20,6 +21,7 @@ export function createServer(): McpServer {
 
   registerSearchTool(server)
   registerFetchTool(server)
+  registerMetadataTool(server)
   registerGuidePrompt(server)
 
   return server

--- a/src/schemas/metadataSchema.ts
+++ b/src/schemas/metadataSchema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+
+export const metadataSchema = z.object({
+  celex_id: z.string()
+    .regex(/^\d[A-Z0-9]{4,20}$/)
+    .describe("CELEX-Identifier, z.B. '32024R1689' für den AI Act"),
+  language: z.enum(["DEU", "ENG", "FRA"])
+    .default("DEU")
+    .describe("Sprache für Titel und EuroVoc-Labels"),
+}).strict()
+
+export type MetadataInput = z.infer<typeof metadataSchema>

--- a/src/services/cellarClient.ts
+++ b/src/services/cellarClient.ts
@@ -5,7 +5,7 @@ import {
   DEFAULT_LANGUAGE,
   DEFAULT_LIMIT,
 } from '../constants.js';
-import type { SparqlQueryParams, SearchResult } from '../types.js';
+import type { SparqlQueryParams, SearchResult, MetadataResult } from '../types.js';
 
 /** Maps 3-letter language codes to CDM expression language URI suffixes */
 const LANGUAGE_URI_MAP: Record<string, string> = {
@@ -25,6 +25,24 @@ const LANGUAGE_HTTP_MAP: Record<string, string> = {
 interface SparqlBindingValue {
   type: string;
   value: string;
+}
+
+/** Shape of the metadata SPARQL JSON results */
+interface MetadataSparqlResponse {
+  results: {
+    bindings: Array<{
+      title?: SparqlBindingValue;
+      dateDoc?: SparqlBindingValue;
+      dateForce?: SparqlBindingValue;
+      dateEnd?: SparqlBindingValue;
+      inForce?: SparqlBindingValue;
+      dateTrans?: SparqlBindingValue;
+      resType?: SparqlBindingValue;
+      authors?: SparqlBindingValue;
+      eurovoc?: SparqlBindingValue;
+      dirCodes?: SparqlBindingValue;
+    }>;
+  };
 }
 
 /** Shape of the SPARQL JSON results */
@@ -192,5 +210,110 @@ export class CellarClient {
     }
 
     return response.text();
+  }
+
+  /**
+   * Builds a SPARQL query to retrieve metadata for a given CELEX ID.
+   */
+  buildMetadataQuery(celexId: string, language: string): string {
+    const lang = LANGUAGE_URI_MAP[language] ?? language;
+    const langLower = LANGUAGE_HTTP_MAP[language] ?? 'de';
+
+    const query = [
+      'PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>',
+      'PREFIX skos: <http://www.w3.org/2004/02/skos/core#>',
+      'PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>',
+      '',
+      'SELECT ?title ?dateDoc ?dateForce ?dateEnd ?inForce ?dateTrans ?resType',
+      '  (GROUP_CONCAT(DISTINCT ?authorName; separator="|||") AS ?authors)',
+      '  (GROUP_CONCAT(DISTINCT ?evLabel; separator="|||") AS ?eurovoc)',
+      '  (GROUP_CONCAT(DISTINCT ?dirCode; separator="|||") AS ?dirCodes)',
+      'WHERE {',
+      `  ?work cdm:resource_legal_id_celex ?celexVal .`,
+      `  FILTER(STR(?celexVal) = "${celexId}")`,
+      `  ?expr cdm:expression_belongs_to_work ?work .`,
+      `  ?expr cdm:expression_uses_language <http://publications.europa.eu/resource/authority/language/${lang}> .`,
+      `  ?expr cdm:expression_title ?title .`,
+      '  OPTIONAL { ?work cdm:work_date_document ?dateDoc . }',
+      '  OPTIONAL { ?work cdm:resource_legal_date_entry-into-force ?dateForce . }',
+      '  OPTIONAL { ?work cdm:resource_legal_date_end-of-validity ?dateEnd . }',
+      '  OPTIONAL { ?work cdm:resource_legal_in-force ?inForce . }',
+      '  OPTIONAL { ?work cdm:resource_legal_date_transposition ?dateTrans . }',
+      '  OPTIONAL {',
+      '    ?work cdm:work_has_resource-type ?resTypeUri .',
+      '    BIND(REPLACE(STR(?resTypeUri), "^.*/", "") AS ?resType)',
+      '  }',
+      '  OPTIONAL {',
+      '    ?work cdm:work_created_by_agent ?agent .',
+      '    ?agent cdm:agent_name ?authorName .',
+      '  }',
+      '  OPTIONAL {',
+      '    ?work cdm:work_is_about_concept_eurovoc ?evConcept .',
+      '    ?evConcept skos:prefLabel ?evLabel .',
+      `    FILTER(LANG(?evLabel) = "${langLower}")`,
+      '  }',
+      '  OPTIONAL {',
+      '    ?work cdm:resource_legal_is_about_concept_directory-code ?dirCode .',
+      '  }',
+      '}',
+      'GROUP BY ?title ?dateDoc ?dateForce ?dateEnd ?inForce ?dateTrans ?resType',
+    ].join('\n');
+
+    return query;
+  }
+
+  /**
+   * Fetches metadata for a CELEX ID from the SPARQL endpoint.
+   */
+  async metadataQuery(celexId: string, language: string): Promise<MetadataResult> {
+    const sparql = this.buildMetadataQuery(celexId, language);
+
+    const response = await fetch(SPARQL_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/sparql-query',
+        Accept: 'application/sparql-results+json',
+      },
+      body: sparql,
+    });
+
+    if (!response.ok) {
+      throw new Error(`SPARQL endpoint error: ${response.status}`);
+    }
+
+    const data = (await response.json()) as MetadataSparqlResponse;
+
+    if (data.results.bindings.length === 0) {
+      throw new Error(`No metadata found for CELEX: ${celexId}`);
+    }
+
+    const binding = data.results.bindings[0];
+    const httpLang = LANGUAGE_HTTP_MAP[language] ?? 'de';
+
+    const splitConcat = (value: string | undefined): string[] => {
+      if (!value) return [];
+      return value.split('|||').filter((s) => s !== '');
+    };
+
+    const parseInForce = (value: string | undefined): boolean | null => {
+      if (value === 'true' || value === '1') return true;
+      if (value === 'false' || value === '0') return false;
+      return null;
+    };
+
+    return {
+      celex_id: celexId,
+      title: binding.title?.value ?? '',
+      date_document: binding.dateDoc?.value ?? '',
+      date_entry_into_force: binding.dateForce?.value ?? '',
+      date_end_of_validity: binding.dateEnd?.value ?? '',
+      in_force: parseInForce(binding.inForce?.value),
+      date_transposition: binding.dateTrans?.value ?? '',
+      resource_type: binding.resType?.value ?? '',
+      authors: splitConcat(binding.authors?.value),
+      eurovoc_concepts: splitConcat(binding.eurovoc?.value),
+      directory_codes: splitConcat(binding.dirCodes?.value),
+      eurlex_url: `${EURLEX_BASE}/${httpLang}/TXT/?uri=CELEX:${celexId}`,
+    };
   }
 }

--- a/src/services/cellarClient.ts
+++ b/src/services/cellarClient.ts
@@ -230,7 +230,7 @@ export class CellarClient {
       '  (GROUP_CONCAT(DISTINCT ?dirCode; separator="|||") AS ?dirCodes)',
       'WHERE {',
       `  ?work cdm:resource_legal_id_celex ?celexVal .`,
-      `  FILTER(STR(?celexVal) = "${celexId}")`,
+      `  FILTER(STR(?celexVal) = "${escapeSparqlString(celexId)}")`,
       `  ?expr cdm:expression_belongs_to_work ?work .`,
       `  ?expr cdm:expression_uses_language <http://publications.europa.eu/resource/authority/language/${lang}> .`,
       `  ?expr cdm:expression_title ?title .`,

--- a/src/services/cellarClient.ts
+++ b/src/services/cellarClient.ts
@@ -185,18 +185,18 @@ export class CellarClient {
   }
 
   /**
-   * Fetches a document from EUR-Lex by CELEX identifier.
-   * Uses the EUR-Lex HTML endpoint which is more reliable than the Cellar REST API
-   * (Cellar often returns HTTP 202 with empty body for content negotiation).
+   * Fetches a document from Cellar by CELEX identifier using content negotiation.
+   * Uses Accept-Language header to select the language variant.
    */
   async fetchDocument(celex_id: string, language: string): Promise<string> {
     const httpLang = LANGUAGE_HTTP_MAP[language] ?? 'de';
-    const url = `${EURLEX_BASE}/${httpLang.toUpperCase()}/TXT/HTML/?uri=CELEX:${celex_id}`;
+    const url = `${CELLAR_REST_BASE}/${celex_id}`;
 
     const response = await fetch(url, {
       method: 'GET',
       headers: {
-        Accept: 'text/html',
+        Accept: 'application/xhtml+xml',
+        'Accept-Language': httpLang,
       },
       redirect: 'follow',
     });

--- a/src/tools/metadata.ts
+++ b/src/tools/metadata.ts
@@ -1,0 +1,33 @@
+import { metadataSchema } from '../schemas/metadataSchema.js'
+import { CellarClient } from '../services/cellarClient.js'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+export async function handleEurlexMetadata(input: {
+  celex_id: string
+  language: string
+}) {
+  try {
+    const parsed = metadataSchema.parse(input)
+    const client = new CellarClient()
+    const result = await client.metadataQuery(parsed.celex_id, parsed.language)
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(result) }],
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      content: [{ type: 'text' as const, text: `Error: ${message}` }],
+      isError: true,
+    }
+  }
+}
+
+export function registerMetadataTool(server: McpServer) {
+  server.tool(
+    'eurlex_metadata',
+    'Ruft detaillierte Metadaten eines EU-Rechtsakts per CELEX-ID ab (Daten, Autoren, EuroVoc, Directory-Codes)',
+    metadataSchema.shape,
+    { readOnlyHint: true, destructiveHint: false },
+    async (params) => handleEurlexMetadata(params)
+  )
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,3 +30,18 @@ export interface SearchToolOutput {
   total: number
   query_used: string
 }
+
+export interface MetadataResult {
+  celex_id: string
+  title: string
+  date_document: string
+  date_entry_into_force: string
+  date_end_of_validity: string
+  in_force: boolean | null
+  date_transposition: string
+  resource_type: string
+  authors: string[]
+  eurovoc_concepts: string[]
+  directory_codes: string[]
+  eurlex_url: string
+}

--- a/tests/cellarClient.metadata.test.ts
+++ b/tests/cellarClient.metadata.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { CellarClient } from '../src/services/cellarClient.js'
+
+const mockFetch = vi.fn()
+
+describe('CellarClient – Metadata', () => {
+  const client = new CellarClient()
+
+  beforeEach(() => {
+    mockFetch.mockReset()
+    vi.stubGlobal('fetch', mockFetch)
+  })
+
+  // =========================================================================
+  // buildMetadataQuery()
+  // =========================================================================
+  describe('buildMetadataQuery()', () => {
+    it('M4 – query contains CELEX filter (resource_legal_id_celex with FILTER)', () => {
+      const sparql = client.buildMetadataQuery('32021R0694', 'DEU')
+      expect(sparql).toContain('resource_legal_id_celex')
+      expect(sparql).toContain('32021R0694')
+      expect(sparql).toContain('FILTER(STR(?celexVal)')
+    })
+
+    it('M5 – query contains all CDM properties', () => {
+      const sparql = client.buildMetadataQuery('32021R0694', 'DEU')
+
+      expect(sparql).toContain('work_date_document')
+      expect(sparql).toContain('resource_legal_date_entry-into-force')
+      expect(sparql).toContain('resource_legal_date_end-of-validity')
+      expect(sparql).toContain('resource_legal_in-force')
+      expect(sparql).toContain('work_created_by_agent')
+      expect(sparql).toContain('work_is_about_concept_eurovoc')
+      expect(sparql).toContain('resource_legal_is_about_concept_directory-code')
+    })
+
+    it('M5b – query uses correct language URI for expression title', () => {
+      const sparqlDeu = client.buildMetadataQuery('32021R0694', 'DEU')
+      expect(sparqlDeu).toContain('language/DEU')
+
+      const sparqlEng = client.buildMetadataQuery('32021R0694', 'ENG')
+      expect(sparqlEng).toContain('language/ENG')
+    })
+
+    it('M5c – query uses GROUP_CONCAT for multi-value fields', () => {
+      const sparql = client.buildMetadataQuery('32021R0694', 'DEU')
+
+      // Should have GROUP_CONCAT with ||| separator for authors, eurovoc, dirCodes
+      const groupConcatMatches = sparql.match(/GROUP_CONCAT/g) || []
+      expect(groupConcatMatches.length).toBeGreaterThanOrEqual(3)
+      expect(sparql).toContain('|||')
+    })
+
+    it('M5d – query includes skos:prefLabel for EuroVoc labels', () => {
+      const sparql = client.buildMetadataQuery('32021R0694', 'DEU')
+
+      expect(sparql).toContain('skos:prefLabel')
+      expect(sparql).toContain('PREFIX skos:')
+    })
+  })
+
+  // =========================================================================
+  // metadataQuery()
+  // =========================================================================
+  describe('metadataQuery()', () => {
+    function makeMetadataSparqlResponse(binding: Record<string, { type: string; value: string }>) {
+      return {
+        results: {
+          bindings: [binding],
+        },
+      }
+    }
+
+    const fullBinding = {
+      title: { type: 'literal', value: 'Regulation on carbon border adjustment' },
+      dateDoc: { type: 'literal', value: '2021-05-01' },
+      dateForce: { type: 'literal', value: '2021-10-01' },
+      dateEnd: { type: 'literal', value: '2030-12-31' },
+      inForce: { type: 'literal', value: 'true' },
+      dateTrans: { type: 'literal', value: '2023-01-01' },
+      resType: { type: 'literal', value: 'REG' },
+      authors: { type: 'literal', value: 'European Commission|||Council of the European Union' },
+      eurovoc: { type: 'literal', value: 'climate change|||carbon tax' },
+      dirCodes: { type: 'literal', value: '11.60.30|||15.10.20' },
+    }
+
+    it('M6 – returns MetadataResult with all fields populated', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => makeMetadataSparqlResponse(fullBinding),
+      })
+
+      const result = await client.metadataQuery('32021R0694', 'DEU')
+
+      expect(result).toMatchObject({
+        celex_id: '32021R0694',
+        title: 'Regulation on carbon border adjustment',
+        date_document: '2021-05-01',
+        date_entry_into_force: '2021-10-01',
+        date_end_of_validity: '2030-12-31',
+        in_force: true,
+        date_transposition: '2023-01-01',
+        resource_type: 'REG',
+        authors: ['European Commission', 'Council of the European Union'],
+        eurovoc_concepts: ['climate change', 'carbon tax'],
+        directory_codes: ['11.60.30', '15.10.20'],
+      })
+      expect(result.eurlex_url).toContain('CELEX:32021R0694')
+      expect(result.eurlex_url).toContain('/de/')
+    })
+
+    it('M7 – returns empty strings/arrays for missing optional fields', async () => {
+      const minimalBinding = {
+        title: { type: 'literal', value: 'Minimal document' },
+      }
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => makeMetadataSparqlResponse(minimalBinding),
+      })
+
+      const result = await client.metadataQuery('32021R0694', 'DEU')
+
+      expect(result.title).toBe('Minimal document')
+      expect(result.date_document).toBe('')
+      expect(result.date_entry_into_force).toBe('')
+      expect(result.date_end_of_validity).toBe('')
+      expect(result.in_force).toBeNull()
+      expect(result.date_transposition).toBe('')
+      expect(result.resource_type).toBe('')
+      expect(result.authors).toEqual([])
+      expect(result.eurovoc_concepts).toEqual([])
+      expect(result.directory_codes).toEqual([])
+    })
+
+    it('M8 – throws on SPARQL endpoint error (HTTP 500)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      })
+
+      await expect(client.metadataQuery('32021R0694', 'DEU')).rejects.toThrow(
+        'SPARQL endpoint error: 500'
+      )
+    })
+
+    it('M8b – correctly parses in_force as boolean', async () => {
+      // true case
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () =>
+          makeMetadataSparqlResponse({
+            ...fullBinding,
+            inForce: { type: 'literal', value: 'true' },
+          }),
+      })
+      const resultTrue = await client.metadataQuery('32021R0694', 'DEU')
+      expect(resultTrue.in_force).toBe(true)
+
+      // false case
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () =>
+          makeMetadataSparqlResponse({
+            ...fullBinding,
+            inForce: { type: 'literal', value: 'false' },
+          }),
+      })
+      const resultFalse = await client.metadataQuery('32021R0694', 'DEU')
+      expect(resultFalse.in_force).toBe(false)
+
+      // "1" case (xsd:boolean alternate)
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () =>
+          makeMetadataSparqlResponse({
+            ...fullBinding,
+            inForce: { type: 'literal', value: '1' },
+          }),
+      })
+      const result1 = await client.metadataQuery('32021R0694', 'DEU')
+      expect(result1.in_force).toBe(true)
+
+      // "0" case (xsd:boolean alternate)
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () =>
+          makeMetadataSparqlResponse({
+            ...fullBinding,
+            inForce: { type: 'literal', value: '0' },
+          }),
+      })
+      const result0 = await client.metadataQuery('32021R0694', 'DEU')
+      expect(result0.in_force).toBe(false)
+
+      // missing case
+      const { inForce: _removed, ...bindingNoForce } = fullBinding
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => makeMetadataSparqlResponse(bindingNoForce),
+      })
+      const resultNull = await client.metadataQuery('32021R0694', 'DEU')
+      expect(resultNull.in_force).toBeNull()
+    })
+
+    it('M8c – correctly splits GROUP_CONCAT values into arrays', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () =>
+          makeMetadataSparqlResponse({
+            ...fullBinding,
+            authors: { type: 'literal', value: 'Author A|||Author B|||Author C' },
+            eurovoc: { type: 'literal', value: 'concept1' },
+            dirCodes: { type: 'literal', value: '' },
+          }),
+      })
+
+      const result = await client.metadataQuery('32021R0694', 'DEU')
+
+      expect(result.authors).toEqual(['Author A', 'Author B', 'Author C'])
+      expect(result.eurovoc_concepts).toEqual(['concept1'])
+      expect(result.directory_codes).toEqual([])
+    })
+  })
+})

--- a/tests/cellarClient.metadata.test.ts
+++ b/tests/cellarClient.metadata.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { CellarClient } from '../src/services/cellarClient.js'
+import { CellarClient, escapeSparqlString } from '../src/services/cellarClient.js'
 
 const mockFetch = vi.fn()
 
@@ -49,6 +49,16 @@ describe('CellarClient – Metadata', () => {
       const groupConcatMatches = sparql.match(/GROUP_CONCAT/g) || []
       expect(groupConcatMatches.length).toBeGreaterThanOrEqual(3)
       expect(sparql).toContain('|||')
+    })
+
+    it('M5e – query escapes double-quotes in CELEX ID via escapeSparqlString', () => {
+      const malicious = '32021R"0694'
+      const sparql = client.buildMetadataQuery(malicious, 'DEU')
+
+      // The escaped form should appear in the SPARQL FILTER
+      expect(sparql).toContain('32021R\\"0694')
+      // The raw unescaped double-quote must NOT appear bare in the query
+      expect(sparql).not.toMatch(/32021R"0694/)
     })
 
     it('M5d – query includes skos:prefLabel for EuroVoc labels', () => {

--- a/tests/cellarClient.metadata.test.ts
+++ b/tests/cellarClient.metadata.test.ts
@@ -133,6 +133,17 @@ describe('CellarClient – Metadata', () => {
       expect(result.directory_codes).toEqual([])
     })
 
+    it('M7b – throws when no bindings returned (CELEX not found)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ results: { bindings: [] } }),
+      })
+
+      await expect(client.metadataQuery('39999X0000', 'DEU')).rejects.toThrow(
+        'No metadata found for CELEX: 39999X0000'
+      )
+    })
+
     it('M8 – throws on SPARQL endpoint error (HTTP 500)', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,

--- a/tests/cellarClient.test.ts
+++ b/tests/cellarClient.test.ts
@@ -141,7 +141,7 @@ describe('fetchDocument()', () => {
     await expect(client.fetchDocument('00000X0000', 'DEU')).rejects.toThrow('Document not found: 00000X0000')
   })
 
-  it('T8 – uses EUR-Lex HTML URL with correct language path', async () => {
+  it('T8 – uses Cellar REST URL with content negotiation headers', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       text: async () => '<html></html>',
@@ -153,13 +153,14 @@ describe('fetchDocument()', () => {
     expect(mockFetch).toHaveBeenCalledOnce()
     const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit]
 
-    expect(url).toBe('https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32021R0694')
+    expect(url).toBe('https://publications.europa.eu/resource/celex/32021R0694')
 
     const headers = options.headers as Record<string, string>
-    expect(headers['Accept']).toBe('text/html')
+    expect(headers['Accept']).toBe('application/xhtml+xml')
+    expect(headers['Accept-Language']).toBe('en')
   })
 
-  it('T9 – maps DEU to DE in EUR-Lex URL path', async () => {
+  it('T9 – maps DEU to de in Accept-Language header', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       text: async () => '<html></html>',
@@ -169,8 +170,9 @@ describe('fetchDocument()', () => {
     await client.fetchDocument('32021R0694', 'DEU')
 
     expect(mockFetch).toHaveBeenCalledOnce()
-    const [url] = mockFetch.mock.calls[0] as [string, RequestInit]
-    expect(url).toContain('/DE/TXT/HTML/')
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit]
+    const headers = options.headers as Record<string, string>
+    expect(headers['Accept-Language']).toBe('de')
   })
 })
 

--- a/tests/eval/phase4-server.eval.test.ts
+++ b/tests/eval/phase4-server.eval.test.ts
@@ -51,15 +51,15 @@ describe('Phase 4 Eval – Server', () => {
     expect(server1).not.toBe(server2)
   })
 
-  it('server registers exactly 2 tools: eurlex_search, eurlex_fetch', async () => {
+  it('server registers exactly 3 tools: eurlex_search, eurlex_fetch, eurlex_metadata', async () => {
     const pair = await createTestPair()
     pairs.push(pair)
 
     const { tools } = await pair.client.listTools()
     const toolNames = tools.map((t) => t.name).sort()
 
-    expect(tools).toHaveLength(2)
-    expect(toolNames).toEqual(['eurlex_fetch', 'eurlex_search'])
+    expect(tools).toHaveLength(3)
+    expect(toolNames).toEqual(['eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
   })
 
   it('eurlex_search has annotations readOnlyHint=true, destructiveHint=false', async () => {

--- a/tests/eval/phase5-validation.eval.test.ts
+++ b/tests/eval/phase5-validation.eval.test.ts
@@ -311,7 +311,7 @@ describe('Phase 5 Eval – Validation Matrix', () => {
       const { tools } = await pair.client.listTools()
       const toolNames = tools.map((t) => t.name).sort()
 
-      expect(toolNames).toEqual(['eurlex_fetch', 'eurlex_search'])
+      expect(toolNames).toEqual(['eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
     })
 
     it('V20: two createServer calls return different instances', async () => {
@@ -325,8 +325,8 @@ describe('Phase 5 Eval – Validation Matrix', () => {
       const { tools: tools1 } = await pair1.client.listTools()
       const { tools: tools2 } = await pair2.client.listTools()
 
-      expect(tools1.map((t) => t.name).sort()).toEqual(['eurlex_fetch', 'eurlex_search'])
-      expect(tools2.map((t) => t.name).sort()).toEqual(['eurlex_fetch', 'eurlex_search'])
+      expect(tools1.map((t) => t.name).sort()).toEqual(['eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+      expect(tools2.map((t) => t.name).sort()).toEqual(['eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
     })
 
     it('V22: listPrompts returns eurlex_guide', async () => {

--- a/tests/eval/phase5-validation.eval.test.ts
+++ b/tests/eval/phase5-validation.eval.test.ts
@@ -164,7 +164,7 @@ describe('Phase 5 Eval – Validation Matrix', () => {
       expect(sparql).toContain('2023-01-15')
     })
 
-    it('V10: fetchDocument uses Accept: text/html via EUR-Lex URL', async () => {
+    it('V10: fetchDocument uses Cellar REST API with content negotiation', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         text: async () => '<html></html>',
@@ -175,12 +175,12 @@ describe('Phase 5 Eval – Validation Matrix', () => {
 
       expect(mockFetch).toHaveBeenCalledOnce()
       const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit]
-      expect(url).toContain('eur-lex.europa.eu')
+      expect(url).toContain('publications.europa.eu/resource/celex')
       const headers = options.headers as Record<string, string>
-      expect(headers['Accept']).toBe('text/html')
+      expect(headers['Accept']).toBe('application/xhtml+xml')
     })
 
-    it('V11: fetchDocument DEU uses DE in EUR-Lex URL path', async () => {
+    it('V11: fetchDocument DEU sets Accept-Language: de', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         text: async () => '<html></html>',
@@ -190,8 +190,9 @@ describe('Phase 5 Eval – Validation Matrix', () => {
       await client.fetchDocument('32024R1689', 'DEU')
 
       expect(mockFetch).toHaveBeenCalledOnce()
-      const [url] = mockFetch.mock.calls[0] as [string, RequestInit]
-      expect(url).toContain('/DE/TXT/HTML/')
+      const [, options] = mockFetch.mock.calls[0] as [string, RequestInit]
+      const headers = options.headers as Record<string, string>
+      expect(headers['Accept-Language']).toBe('de')
     })
 
     it('V12: buildSparqlQuery contains BIND and ?resType', () => {

--- a/tests/integration/live.test.ts
+++ b/tests/integration/live.test.ts
@@ -62,4 +62,18 @@ describe('Phase 5 – Live Validation', () => {
     expect(typeof content).toBe('string')
     expect(content.length).toBeGreaterThan(10_000)
   }, TIMEOUT)
+
+  // M-LIVE-1: Metadata for AI Act retrievable with real data
+  it('M-LIVE-1: metadataQuery returns metadata for AI Act (32024R1689)', async () => {
+    const result = await client.metadataQuery('32024R1689', 'DEU')
+
+    expect(result.celex_id).toBe('32024R1689')
+    expect(result.title).toBeDefined()
+    expect(result.title.length).toBeGreaterThan(0)
+    expect(Array.isArray(result.authors)).toBe(true)
+    expect(result.eurovoc_concepts.length).toBeGreaterThan(0)
+    expect(result.in_force).toBe(true)
+    expect(result.resource_type).toBe('REG')
+    expect(result.eurlex_url).toContain('32024R1689')
+  }, TIMEOUT)
 })

--- a/tests/metadata.tool.test.ts
+++ b/tests/metadata.tool.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mock CellarClient — must be before importing the tool handler
+// ---------------------------------------------------------------------------
+const mockMetadataQuery = vi.fn()
+
+vi.mock('../src/services/cellarClient.js', () => ({
+  CellarClient: vi.fn().mockImplementation(() => ({
+    metadataQuery: mockMetadataQuery,
+  })),
+}))
+
+import { handleEurlexMetadata } from '../src/tools/metadata.js'
+
+// ---------------------------------------------------------------------------
+// Reset mocks between tests
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// Shared mock data
+// ---------------------------------------------------------------------------
+const mockResult = {
+  celex_id: '32024R1689',
+  title: 'AI Act',
+  date_document: '2024-06-13',
+  date_entry_into_force: '2024-08-01',
+  date_end_of_validity: '',
+  in_force: true,
+  date_transposition: '',
+  resource_type: 'REG',
+  authors: ['EP', 'CONSIL'],
+  eurovoc_concepts: ['artificial intelligence', 'high risk'],
+  directory_codes: ['16.40.10'],
+  eurlex_url: 'https://eur-lex.europa.eu/legal-content/de/TXT/?uri=CELEX:32024R1689',
+}
+
+// ===========================================================================
+// Tests: handleEurlexMetadata tool handler
+// ===========================================================================
+describe('handleEurlexMetadata()', () => {
+  it('M9 – returns metadata JSON on success', async () => {
+    mockMetadataQuery.mockResolvedValueOnce(mockResult)
+
+    const result = await handleEurlexMetadata({
+      celex_id: '32024R1689',
+      language: 'DEU',
+    })
+
+    expect(result.content).toHaveLength(1)
+    expect(result.content[0].type).toBe('text')
+    expect(result).not.toHaveProperty('isError')
+
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed.celex_id).toBe('32024R1689')
+    expect(parsed.title).toBe('AI Act')
+  })
+
+  it('M10 – returns isError on CellarClient error', async () => {
+    mockMetadataQuery.mockRejectedValueOnce(new Error('SPARQL endpoint unavailable'))
+
+    const result = await handleEurlexMetadata({
+      celex_id: '32024R1689',
+      language: 'DEU',
+    })
+
+    expect(result.isError).toBe(true)
+    expect(result.content).toHaveLength(1)
+    expect(result.content[0].type).toBe('text')
+    expect(result.content[0].text).toContain('SPARQL endpoint unavailable')
+  })
+
+  it('M10b – returns isError on invalid CELEX ID', async () => {
+    const result = await handleEurlexMetadata({
+      celex_id: 'INVALID!!!',
+      language: 'DEU',
+    })
+
+    expect(result.isError).toBe(true)
+    expect(result.content).toHaveLength(1)
+    expect(result.content[0].type).toBe('text')
+    expect(result.content[0].text).toMatch(/Error:/)
+  })
+
+  it('M10c – returned JSON contains all MetadataResult fields', async () => {
+    mockMetadataQuery.mockResolvedValueOnce(mockResult)
+
+    const result = await handleEurlexMetadata({
+      celex_id: '32024R1689',
+      language: 'DEU',
+    })
+
+    expect(result).not.toHaveProperty('isError')
+
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed).toHaveProperty('celex_id')
+    expect(parsed).toHaveProperty('title')
+    expect(parsed).toHaveProperty('date_document')
+    expect(parsed).toHaveProperty('date_entry_into_force')
+    expect(parsed).toHaveProperty('date_end_of_validity')
+    expect(parsed).toHaveProperty('in_force')
+    expect(parsed).toHaveProperty('date_transposition')
+    expect(parsed).toHaveProperty('resource_type')
+    expect(parsed).toHaveProperty('authors')
+    expect(parsed).toHaveProperty('eurovoc_concepts')
+    expect(parsed).toHaveProperty('directory_codes')
+    expect(parsed).toHaveProperty('eurlex_url')
+
+    expect(Array.isArray(parsed.authors)).toBe(true)
+    expect(Array.isArray(parsed.eurovoc_concepts)).toBe(true)
+    expect(Array.isArray(parsed.directory_codes)).toBe(true)
+  })
+})

--- a/tests/metadataSchema.test.ts
+++ b/tests/metadataSchema.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { ZodError } from 'zod'
+import { metadataSchema } from '../src/schemas/metadataSchema.js'
+
+// ===========================================================================
+// Tests M1-M6: metadataSchema validation
+// ===========================================================================
+describe('metadataSchema', () => {
+  it('M1 – valid CELEX ID with default language → parse succeeds, language defaults to "DEU"', () => {
+    const result = metadataSchema.parse({ celex_id: '32024R1689' })
+
+    expect(result.celex_id).toBe('32024R1689')
+    expect(result.language).toBe('DEU')
+  })
+
+  it('M2 – valid CELEX ID with explicit language "ENG" → parse succeeds', () => {
+    const result = metadataSchema.parse({ celex_id: '32024R1689', language: 'ENG' })
+
+    expect(result.celex_id).toBe('32024R1689')
+    expect(result.language).toBe('ENG')
+  })
+
+  it('M3 – invalid CELEX ID throws ZodError', () => {
+    expect(() => metadataSchema.parse({ celex_id: 'invalid' })).toThrow(ZodError)
+    expect(() => metadataSchema.parse({ celex_id: 'abc' })).toThrow(ZodError)
+    expect(() => metadataSchema.parse({ celex_id: '' })).toThrow(ZodError)
+  })
+
+  it('M4 – extra fields rejected in strict mode', () => {
+    expect(() =>
+      metadataSchema.parse({ celex_id: '32024R1689', language: 'DEU', extra: 'field' })
+    ).toThrow(ZodError)
+  })
+
+  it('M5 – all three languages accepted', () => {
+    for (const lang of ['DEU', 'ENG', 'FRA'] as const) {
+      const result = metadataSchema.parse({ celex_id: '32024R1689', language: lang })
+      expect(result.language).toBe(lang)
+    }
+  })
+
+  it('M6 – invalid language rejected', () => {
+    expect(() =>
+      metadataSchema.parse({ celex_id: '32024R1689', language: 'ESP' })
+    ).toThrow(ZodError)
+  })
+})

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -55,7 +55,7 @@ describe('Phase 5 – Smoke Tests', () => {
     const { tools } = await pair.client.listTools()
     const toolNames = tools.map((t) => t.name).sort()
 
-    expect(toolNames).toEqual(['eurlex_fetch', 'eurlex_search'])
+    expect(toolNames).toEqual(['eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
   })
 
   // V20: Session-Management → factory creates independent servers per call
@@ -68,8 +68,8 @@ describe('Phase 5 – Smoke Tests', () => {
     const { tools: tools1 } = await pair1.client.listTools()
     const { tools: tools2 } = await pair2.client.listTools()
 
-    expect(tools1.map((t) => t.name).sort()).toEqual(['eurlex_fetch', 'eurlex_search'])
-    expect(tools2.map((t) => t.name).sort()).toEqual(['eurlex_fetch', 'eurlex_search'])
+    expect(tools1.map((t) => t.name).sort()).toEqual(['eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+    expect(tools2.map((t) => t.name).sort()).toEqual(['eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
 
     // They should be distinct object instances
     expect(pair1.server).not.toBe(pair2.server)
@@ -98,6 +98,18 @@ describe('Phase 5 – Smoke Tests', () => {
     expect(fetch?.annotations).toBeDefined()
     expect(fetch?.annotations?.readOnlyHint).toBe(true)
     expect(fetch?.annotations?.destructiveHint).toBe(false)
+  })
+
+  it('eurlex_metadata has annotations readOnlyHint=true, destructiveHint=false', async () => {
+    const pair = await createTestPair()
+    pairs.push(pair)
+
+    const { tools } = await pair.client.listTools()
+    const metadata = tools.find((t) => t.name === 'eurlex_metadata')
+
+    expect(metadata?.annotations).toBeDefined()
+    expect(metadata?.annotations?.readOnlyHint).toBe(true)
+    expect(metadata?.annotations?.destructiveHint).toBe(false)
   })
 
   // V22: eurlex_guide Prompt abrufbar → server has eurlex_guide prompt registered


### PR DESCRIPTION
## Summary
- **New `eurlex_metadata` tool**: Retrieves detailed metadata for EU legal acts by CELEX ID via SPARQL (title, dates, in-force status, EuroVoc concepts, directory codes)
- **Fix `fetchDocument` WAF blockade**: Switched from EUR-Lex HTML endpoint (blocked by AWS WAF bot protection) to Cellar REST API with content negotiation (`Accept: application/xhtml+xml` + `Accept-Language` header)

## Test plan
- [x] All 149 tests pass (unit, eval, integration)
- [x] V4/V5 fulltext tests now return real document content instead of WAF challenge page
- [x] Live MCP verification: `eurlex_metadata`, `eurlex_fetch`, `eurlex_search` all working