### PR TITLE
Add eurlex_citations tool (Phase 8)

### DIFF
--- a/docs/superpowers/plans/2026-03-10-new-tools-expansion.md
+++ b/docs/superpowers/plans/2026-03-10-new-tools-expansion.md
@@ -642,7 +642,7 @@ export interface CitationEntry {
   title: string
   date: string
   type: string
-  relationship: 'cites' | 'cited_by' | 'amends' | 'amended_by' | 'based_on' | 'basis_for'
+  relationship: 'cites' | 'cited_by' | 'amends' | 'amended_by' | 'based_on' | 'basis_for' | 'repeals' | 'repealed_by'
   eurlex_url: string
 }
 
@@ -736,11 +736,13 @@ describe('buildCitationsQuery()', () => {
     expect(sparql).toContain('UNION')
   })
 
-  it('C8 – includes legal basis relationships', () => {
+  it('C8 – includes legal basis, amends, and repeals relationships', () => {
     const client = new CellarClient()
     const sparql = client.buildCitationsQuery('32024R1689', 'DEU', 'both', 20)
 
     expect(sparql).toContain('resource_legal_based_on_resource_legal')
+    expect(sparql).toContain('resource_legal_amends_resource_legal')
+    expect(sparql).toContain('resource_legal_repeals_resource_legal')
   })
 })
 
@@ -813,7 +815,9 @@ In `src/services/cellarClient.ts`, add to CellarClient class:
       '    UNION',
       '    { ?sourceWork cdm:resource_legal_based_on_resource_legal ?relWork . BIND("based_on" AS ?rel) }',
       '    UNION',
-      '    { ?sourceWork cdm:resource_legal_adopts_resource_legal ?relWork . BIND("amends" AS ?rel) }',
+      '    { ?sourceWork cdm:resource_legal_amends_resource_legal ?relWork . BIND("amends" AS ?rel) }',
+    '    UNION',
+    '    { ?sourceWork cdm:resource_legal_repeals_resource_legal ?relWork . BIND("repeals" AS ?rel) }',
       '  }',
     ].join('\n')
 
@@ -831,9 +835,15 @@ In `src/services/cellarClient.ts`, add to CellarClient class:
       '  }',
       '  UNION',
       '  {',
-      `    ?relWork cdm:resource_legal_adopts_resource_legal ?sourceWork .`,
+      `    ?relWork cdm:resource_legal_amends_resource_legal ?sourceWork .`,
       `    ?sourceWork cdm:resource_legal_id_celex "${escaped}" .`,
       '    BIND("amended_by" AS ?rel)',
+      '  }',
+      '  UNION',
+      '  {',
+      `    ?relWork cdm:resource_legal_repeals_resource_legal ?sourceWork .`,
+      `    ?sourceWork cdm:resource_legal_id_celex "${escaped}" .`,
+      '    BIND("repealed_by" AS ?rel)',
       '  }',
     ].join('\n')
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import express, { type Request, type Response } from 'express'
 import { registerSearchTool } from './tools/search.js'
 import { registerFetchTool } from './tools/fetch.js'
 import { registerMetadataTool } from './tools/metadata.js'
+import { registerCitationsTool } from './tools/citations.js'
 import { registerGuidePrompt } from './prompts/guide.js'
 
 // ---------------------------------------------------------------------------
@@ -22,6 +23,7 @@ export function createServer(): McpServer {
   registerSearchTool(server)
   registerFetchTool(server)
   registerMetadataTool(server)
+  registerCitationsTool(server)
   registerGuidePrompt(server)
 
   return server

--- a/src/schemas/citationsSchema.ts
+++ b/src/schemas/citationsSchema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod'
+
+export const citationsSchema = z.object({
+  celex_id: z.string()
+    .regex(/^\d[A-Z0-9]{4,20}$/)
+    .describe("CELEX-Identifier, z.B. '32024R1689'"),
+  language: z.enum(['DEU', 'ENG', 'FRA'])
+    .default('DEU')
+    .describe('Sprache für Titel'),
+  direction: z.enum(['cites', 'cited_by', 'both'])
+    .default('both')
+    .describe('Richtung: cites=zitiert von diesem Dokument, cited_by=zitiert dieses Dokument, both=beides'),
+  limit: z.number().int().min(1).max(100).default(20)
+    .describe('Max. Ergebnisse'),
+}).strict()
+
+export type CitationsInput = z.infer<typeof citationsSchema>

--- a/src/services/cellarClient.ts
+++ b/src/services/cellarClient.ts
@@ -5,7 +5,7 @@ import {
   DEFAULT_LANGUAGE,
   DEFAULT_LIMIT,
 } from '../constants.js';
-import type { SparqlQueryParams, SearchResult, MetadataResult } from '../types.js';
+import type { SparqlQueryParams, SearchResult, MetadataResult, CitationsResult } from '../types.js';
 
 /** Maps 3-letter language codes to CDM expression language URI suffixes */
 const LANGUAGE_URI_MAP: Record<string, string> = {
@@ -41,6 +41,19 @@ interface MetadataSparqlResponse {
       authors?: SparqlBindingValue;
       eurovoc?: SparqlBindingValue;
       dirCodes?: SparqlBindingValue;
+    }>;
+  };
+}
+
+/** Shape of the citations SPARQL JSON results */
+interface CitationsSparqlResponse {
+  results: {
+    bindings: Array<{
+      celex: SparqlBindingValue;
+      title: SparqlBindingValue;
+      date?: SparqlBindingValue;
+      resType: SparqlBindingValue;
+      rel: SparqlBindingValue;
     }>;
   };
 }
@@ -314,6 +327,122 @@ export class CellarClient {
       eurovoc_concepts: splitConcat(binding.eurovoc?.value),
       directory_codes: splitConcat(binding.dirCodes?.value),
       eurlex_url: `${EURLEX_BASE}/${httpLang}/TXT/?uri=CELEX:${celexId}`,
+    };
+  }
+
+  /**
+   * Builds a SPARQL query to retrieve citations/relationships for a given CELEX ID.
+   */
+  buildCitationsQuery(
+    celexId: string,
+    language: string,
+    direction: 'cites' | 'cited_by' | 'both',
+    limit: number
+  ): string {
+    const lang = LANGUAGE_URI_MAP[language] ?? language;
+    const escaped = escapeSparqlString(celexId);
+
+    const citesBlock = [
+      '  {',
+      `    ?sourceWork cdm:resource_legal_id_celex "${escaped}" .`,
+      '    { ?sourceWork cdm:work_cites_work ?relWork . BIND("cites" AS ?rel) }',
+      '    UNION',
+      '    { ?sourceWork cdm:resource_legal_based_on_resource_legal ?relWork . BIND("based_on" AS ?rel) }',
+      '    UNION',
+      '    { ?sourceWork cdm:resource_legal_amends_resource_legal ?relWork . BIND("amends" AS ?rel) }',
+      '    UNION',
+      '    { ?sourceWork cdm:resource_legal_repeals_resource_legal ?relWork . BIND("repeals" AS ?rel) }',
+      '  }',
+    ].join('\n');
+
+    const citedByBlock = [
+      '  {',
+      `    ?relWork cdm:work_cites_work ?sourceWork .`,
+      `    ?sourceWork cdm:resource_legal_id_celex "${escaped}" .`,
+      '    BIND("cited_by" AS ?rel)',
+      '  }',
+      '  UNION',
+      '  {',
+      `    ?relWork cdm:resource_legal_based_on_resource_legal ?sourceWork .`,
+      `    ?sourceWork cdm:resource_legal_id_celex "${escaped}" .`,
+      '    BIND("basis_for" AS ?rel)',
+      '  }',
+      '  UNION',
+      '  {',
+      `    ?relWork cdm:resource_legal_amends_resource_legal ?sourceWork .`,
+      `    ?sourceWork cdm:resource_legal_id_celex "${escaped}" .`,
+      '    BIND("amended_by" AS ?rel)',
+      '  }',
+      '  UNION',
+      '  {',
+      `    ?relWork cdm:resource_legal_repeals_resource_legal ?sourceWork .`,
+      `    ?sourceWork cdm:resource_legal_id_celex "${escaped}" .`,
+      '    BIND("repealed_by" AS ?rel)',
+      '  }',
+    ].join('\n');
+
+    let body: string;
+    if (direction === 'cites') body = citesBlock;
+    else if (direction === 'cited_by') body = citedByBlock;
+    else body = `${citesBlock}\n  UNION\n${citedByBlock}`;
+
+    return [
+      'PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>',
+      '',
+      'SELECT DISTINCT ?celex ?title ?date ?resType ?rel WHERE {',
+      body,
+      '  ?relWork cdm:resource_legal_id_celex ?celex .',
+      '  ?relWork cdm:work_has_resource-type ?resTypeUri .',
+      '  BIND(REPLACE(STR(?resTypeUri), "^.*/", "") AS ?resType)',
+      `  ?relExpr cdm:expression_belongs_to_work ?relWork .`,
+      `  ?relExpr cdm:expression_uses_language <http://publications.europa.eu/resource/authority/language/${lang}> .`,
+      '  ?relExpr cdm:expression_title ?title .',
+      '  OPTIONAL { ?relWork cdm:work_date_document ?date . }',
+      '}',
+      'ORDER BY DESC(?date)',
+      `LIMIT ${limit}`,
+    ].join('\n');
+  }
+
+  /**
+   * Fetches citations/relationships for a CELEX ID from the SPARQL endpoint.
+   */
+  async citationsQuery(
+    celexId: string,
+    language: string,
+    direction: 'cites' | 'cited_by' | 'both',
+    limit: number
+  ): Promise<CitationsResult> {
+    const sparql = this.buildCitationsQuery(celexId, language, direction, limit);
+    const httpLang = LANGUAGE_HTTP_MAP[language] ?? 'de';
+
+    const response = await fetch(SPARQL_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/sparql-query',
+        Accept: 'application/sparql-results+json',
+      },
+      body: sparql,
+    });
+
+    if (!response.ok) {
+      throw new Error(`SPARQL endpoint error: ${response.status}`);
+    }
+
+    const data = (await response.json()) as CitationsSparqlResponse;
+    const citations = data.results.bindings.map((b) => ({
+      celex: b.celex.value,
+      title: b.title.value,
+      date: b.date?.value ?? '',
+      type: b.resType.value,
+      relationship: b.rel.value,
+      eurlex_url: `${EURLEX_BASE}/${httpLang}/TXT/?uri=CELEX:${b.celex.value}`,
+    }));
+
+    return {
+      celex_id: celexId,
+      citations,
+      total: citations.length,
     };
   }
 }

--- a/src/tools/citations.ts
+++ b/src/tools/citations.ts
@@ -1,0 +1,44 @@
+import { citationsSchema } from '../schemas/citationsSchema.js'
+import { CellarClient } from '../services/cellarClient.js'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+export async function handleEurlexCitations(input: {
+  celex_id: string
+  language: string
+  direction: 'cites' | 'cited_by' | 'both'
+  limit: number
+}) {
+  try {
+    const parsed = citationsSchema.parse(input)
+    const client = new CellarClient()
+    const result = await client.citationsQuery(
+      parsed.celex_id,
+      parsed.language,
+      parsed.direction,
+      parsed.limit
+    )
+
+    return {
+      content: [{
+        type: 'text' as const,
+        text: JSON.stringify(result),
+      }],
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      content: [{ type: 'text' as const, text: `Error: ${message}` }],
+      isError: true,
+    }
+  }
+}
+
+export function registerCitationsTool(server: McpServer) {
+  server.tool(
+    'eurlex_citations',
+    'Findet Zitierungen, Rechtsgrundlagen und Änderungen eines EU-Rechtsakts',
+    citationsSchema.shape,
+    { readOnlyHint: true, destructiveHint: false },
+    async (params) => handleEurlexCitations(params)
+  )
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,3 +45,18 @@ export interface MetadataResult {
   directory_codes: string[]
   eurlex_url: string
 }
+
+export interface CitationEntry {
+  celex: string
+  title: string
+  date: string
+  type: string
+  relationship: 'cites' | 'cited_by' | 'amends' | 'amended_by' | 'based_on' | 'basis_for' | 'repeals' | 'repealed_by'
+  eurlex_url: string
+}
+
+export interface CitationsResult {
+  celex_id: string
+  citations: CitationEntry[]
+  total: number
+}

--- a/tests/cellarClient.citations.test.ts
+++ b/tests/cellarClient.citations.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { CellarClient } from '../src/services/cellarClient.js'
+
+const mockFetch = vi.fn()
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  vi.stubGlobal('fetch', mockFetch)
+})
+
+describe('buildCitationsQuery()', () => {
+  it('C5 – generates SPARQL for "cites" direction with work_cites_work', () => {
+    const client = new CellarClient()
+    const sparql = client.buildCitationsQuery('32024R1689', 'DEU', 'cites', 20)
+
+    expect(sparql).toContain('32024R1689')
+    expect(sparql).toContain('work_cites_work')
+  })
+
+  it('C6 – generates SPARQL for "cited_by" direction', () => {
+    const client = new CellarClient()
+    const sparql = client.buildCitationsQuery('32024R1689', 'DEU', 'cited_by', 20)
+
+    expect(sparql).toContain('32024R1689')
+    expect(sparql).toContain('work_cites_work')
+  })
+
+  it('C7 – generates UNION query for "both" direction', () => {
+    const client = new CellarClient()
+    const sparql = client.buildCitationsQuery('32024R1689', 'DEU', 'both', 20)
+
+    expect(sparql).toContain('UNION')
+  })
+
+  it('C8 – includes legal basis, amends, and repeals relationships', () => {
+    const client = new CellarClient()
+    const sparql = client.buildCitationsQuery('32024R1689', 'DEU', 'both', 20)
+
+    expect(sparql).toContain('resource_legal_based_on_resource_legal')
+    expect(sparql).toContain('resource_legal_amends_resource_legal')
+    expect(sparql).toContain('resource_legal_repeals_resource_legal')
+  })
+})
+
+describe('citationsQuery()', () => {
+  it('C9 – returns CitationsResult with parsed citation entries', async () => {
+    const sparqlResponse = {
+      results: {
+        bindings: [{
+          celex: { type: 'literal', value: '32016R0679' },
+          title: { type: 'literal', value: 'DSGVO' },
+          date: { type: 'literal', value: '2016-04-27' },
+          resType: { type: 'literal', value: 'REG' },
+          rel: { type: 'literal', value: 'cites' },
+        }],
+      },
+    }
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => sparqlResponse,
+    })
+
+    const client = new CellarClient()
+    const result = await client.citationsQuery('32024R1689', 'DEU', 'both', 20)
+
+    expect(result.celex_id).toBe('32024R1689')
+    expect(result.citations).toHaveLength(1)
+    expect(result.citations[0].celex).toBe('32016R0679')
+    expect(result.citations[0].relationship).toBe('cites')
+  })
+
+  it('C10 – returns empty citations array when no relationships found', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: { bindings: [] } }),
+    })
+
+    const client = new CellarClient()
+    const result = await client.citationsQuery('32024R1689', 'DEU', 'both', 20)
+
+    expect(result.citations).toEqual([])
+    expect(result.total).toBe(0)
+  })
+})

--- a/tests/cellarClient.citations.test.ts
+++ b/tests/cellarClient.citations.test.ts
@@ -32,6 +32,15 @@ describe('buildCitationsQuery()', () => {
     expect(sparql).toContain('UNION')
   })
 
+  it('C8a – query escapes double-quotes in CELEX ID for defense-in-depth', () => {
+    const client = new CellarClient()
+    const malicious = '32021R"0694'
+    const sparql = client.buildCitationsQuery(malicious, 'DEU', 'both', 20)
+
+    expect(sparql).toContain('32021R\\"0694')
+    expect(sparql).not.toMatch(/32021R"0694/)
+  })
+
   it('C8 – includes legal basis, amends, and repeals relationships', () => {
     const client = new CellarClient()
     const sparql = client.buildCitationsQuery('32024R1689', 'DEU', 'both', 20)

--- a/tests/citations.tool.test.ts
+++ b/tests/citations.tool.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockCitationsQuery = vi.fn()
+vi.mock('../src/services/cellarClient.js', () => ({
+  CellarClient: vi.fn().mockImplementation(() => ({
+    citationsQuery: mockCitationsQuery,
+  })),
+}))
+
+import { handleEurlexCitations } from '../src/tools/citations.js'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('handleEurlexCitations()', () => {
+  it('C11 – returns citations as JSON in MCP format', async () => {
+    mockCitationsQuery.mockResolvedValueOnce({
+      celex_id: '32024R1689',
+      citations: [{ celex: '32016R0679', title: 'DSGVO', relationship: 'cites' }],
+      total: 1,
+    })
+
+    const result = await handleEurlexCitations({
+      celex_id: '32024R1689',
+      language: 'DEU',
+      direction: 'both',
+      limit: 20,
+    })
+
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed.celex_id).toBe('32024R1689')
+    expect(parsed.citations).toHaveLength(1)
+  })
+
+  it('C12 – returns isError on failure', async () => {
+    mockCitationsQuery.mockRejectedValueOnce(new Error('SPARQL timeout'))
+
+    const result = await handleEurlexCitations({
+      celex_id: '32024R1689',
+      language: 'DEU',
+      direction: 'both',
+      limit: 20,
+    })
+
+    expect(result.isError).toBe(true)
+  })
+})

--- a/tests/citationsSchema.test.ts
+++ b/tests/citationsSchema.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { citationsSchema } from '../src/schemas/citationsSchema.js'
+
+describe('citationsSchema', () => {
+  it('C1 – accepts valid CELEX-ID with defaults', () => {
+    const result = citationsSchema.parse({ celex_id: '32024R1689' })
+    expect(result.celex_id).toBe('32024R1689')
+    expect(result.language).toBe('DEU')
+    expect(result.direction).toBe('both')
+    expect(result.limit).toBe(20)
+  })
+
+  it('C2 – accepts direction=cited_by', () => {
+    const result = citationsSchema.parse({ celex_id: '32024R1689', direction: 'cited_by' })
+    expect(result.direction).toBe('cited_by')
+  })
+
+  it('C3 – accepts direction=cites', () => {
+    const result = citationsSchema.parse({ celex_id: '32024R1689', direction: 'cites' })
+    expect(result.direction).toBe('cites')
+  })
+
+  it('C4 – rejects invalid CELEX-ID', () => {
+    expect(() => citationsSchema.parse({ celex_id: 'bad' })).toThrow()
+  })
+})

--- a/tests/eval/phase4-server.eval.test.ts
+++ b/tests/eval/phase4-server.eval.test.ts
@@ -51,15 +51,15 @@ describe('Phase 4 Eval – Server', () => {
     expect(server1).not.toBe(server2)
   })
 
-  it('server registers exactly 3 tools: eurlex_search, eurlex_fetch, eurlex_metadata', async () => {
+  it('server registers exactly 4 tools: eurlex_citations, eurlex_search, eurlex_fetch, eurlex_metadata', async () => {
     const pair = await createTestPair()
     pairs.push(pair)
 
     const { tools } = await pair.client.listTools()
     const toolNames = tools.map((t) => t.name).sort()
 
-    expect(tools).toHaveLength(3)
-    expect(toolNames).toEqual(['eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+    expect(tools).toHaveLength(4)
+    expect(toolNames).toEqual(['eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
   })
 
   it('eurlex_search has annotations readOnlyHint=true, destructiveHint=false', async () => {

--- a/tests/eval/phase5-validation.eval.test.ts
+++ b/tests/eval/phase5-validation.eval.test.ts
@@ -305,14 +305,14 @@ describe('Phase 5 Eval – Validation Matrix', () => {
       expect(Array.isArray(tools)).toBe(true)
     })
 
-    it('V18: listTools returns exactly eurlex_search and eurlex_fetch', async () => {
+    it('V18: listTools returns all registered tools', async () => {
       const pair = await createTestPair()
       pairs.push(pair)
 
       const { tools } = await pair.client.listTools()
       const toolNames = tools.map((t) => t.name).sort()
 
-      expect(toolNames).toEqual(['eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+      expect(toolNames).toEqual(['eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
     })
 
     it('V20: two createServer calls return different instances', async () => {
@@ -326,8 +326,8 @@ describe('Phase 5 Eval – Validation Matrix', () => {
       const { tools: tools1 } = await pair1.client.listTools()
       const { tools: tools2 } = await pair2.client.listTools()
 
-      expect(tools1.map((t) => t.name).sort()).toEqual(['eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
-      expect(tools2.map((t) => t.name).sort()).toEqual(['eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+      expect(tools1.map((t) => t.name).sort()).toEqual(['eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+      expect(tools2.map((t) => t.name).sort()).toEqual(['eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
     })
 
     it('V22: listPrompts returns eurlex_guide', async () => {

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -55,7 +55,7 @@ describe('Phase 5 – Smoke Tests', () => {
     const { tools } = await pair.client.listTools()
     const toolNames = tools.map((t) => t.name).sort()
 
-    expect(toolNames).toEqual(['eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+    expect(toolNames).toEqual(['eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
   })
 
   // V20: Session-Management → factory creates independent servers per call
@@ -68,8 +68,8 @@ describe('Phase 5 – Smoke Tests', () => {
     const { tools: tools1 } = await pair1.client.listTools()
     const { tools: tools2 } = await pair2.client.listTools()
 
-    expect(tools1.map((t) => t.name).sort()).toEqual(['eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
-    expect(tools2.map((t) => t.name).sort()).toEqual(['eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+    expect(tools1.map((t) => t.name).sort()).toEqual(['eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+    expect(tools2.map((t) => t.name).sort()).toEqual(['eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
 
     // They should be distinct object instances
     expect(pair1.server).not.toBe(pair2.server)
@@ -110,6 +110,18 @@ describe('Phase 5 – Smoke Tests', () => {
     expect(metadata?.annotations).toBeDefined()
     expect(metadata?.annotations?.readOnlyHint).toBe(true)
     expect(metadata?.annotations?.destructiveHint).toBe(false)
+  })
+
+  it('eurlex_citations has annotations readOnlyHint=true, destructiveHint=false', async () => {
+    const pair = await createTestPair()
+    pairs.push(pair)
+
+    const { tools } = await pair.client.listTools()
+    const citations = tools.find((t) => t.name === 'eurlex_citations')
+
+    expect(citations?.annotations).toBeDefined()
+    expect(citations?.annotations?.readOnlyHint).toBe(true)
+    expect(citations?.annotations?.destructiveHint).toBe(false)
   })
 
   // V22: eurlex_guide Prompt abrufbar → server has eurlex_guide prompt registered


### PR DESCRIPTION
## Summary

- Adds `eurlex_citations` tool for bidirectional citation lookup of EU legal acts via SPARQL
- Supports 4 relationship types: **cites**, **based_on**, **amends**, **repeals** (each with reverse direction)
- Uses subject/object swap in SPARQL UNION patterns (OWL inverse properties lack data in triple store)
- Follows existing patterns: Zod schema → CellarClient SPARQL methods → tool handler → MCP registration

## Changes

| File | Change |
|---|---|
| `src/schemas/citationsSchema.ts` | Zod schema: celex_id, language, direction, limit |
| `src/tools/citations.ts` | Handler + MCP registration |
| `src/services/cellarClient.ts` | `buildCitationsQuery()` + `citationsQuery()` + typed `CitationsSparqlResponse` |
| `src/types.ts` | `CitationEntry` + `CitationsResult` interfaces |
| `src/index.ts` | `registerCitationsTool()` call |
| `tests/` | 13 new tests (schema C1-C4, SPARQL C5-C10, handler C11-C12, annotations) |
| `tests/smoke.test.ts` | Updated tool count to 4 |
| `tests/eval/` | Updated tool arrays and descriptions |

## Test plan

- [x] 163/163 tests pass (13 new + 150 existing)
- [x] TDD red/green cycle verified for all 3 tasks
- [x] Code review completed — all findings addressed
- [x] Live API integration tests pass
- [ ] Manual test: `eurlex_citations` with AI Act (32024R1689) returns citation relationships

Closes #2