### PR TITLE
Add eurlex_by_eurovoc tool for EuroVoc thematic search

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { registerSearchTool } from './tools/search.js'
 import { registerFetchTool } from './tools/fetch.js'
 import { registerMetadataTool } from './tools/metadata.js'
 import { registerCitationsTool } from './tools/citations.js'
+import { registerEurovocTool } from './tools/eurovoc.js'
 import { registerGuidePrompt } from './prompts/guide.js'
 
 // ---------------------------------------------------------------------------
@@ -24,6 +25,7 @@ export function createServer(): McpServer {
   registerFetchTool(server)
   registerMetadataTool(server)
   registerCitationsTool(server)
+  registerEurovocTool(server)
   registerGuidePrompt(server)
 
   return server

--- a/src/schemas/eurovocSchema.ts
+++ b/src/schemas/eurovocSchema.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+
+export const eurovocSchema = z.object({
+  concept: z.string().min(2).max(500)
+    .describe("EuroVoc-Konzept: Label (z.B. 'artificial intelligence') oder URI (z.B. 'http://eurovoc.europa.eu/4424')"),
+  resource_type: z.enum(['REG', 'DIR', 'DEC', 'JUDG', 'any'])
+    .default('any')
+    .describe('Dokumenttyp-Filter'),
+  language: z.enum(['DEU', 'ENG', 'FRA'])
+    .default('DEU')
+    .describe('Sprache für Titel und EuroVoc-Labels'),
+  limit: z.number().int().min(1).max(50).default(10)
+    .describe('Max. Ergebnisse'),
+}).strict()
+
+export type EurovocInput = z.infer<typeof eurovocSchema>

--- a/src/services/cellarClient.ts
+++ b/src/services/cellarClient.ts
@@ -445,4 +445,86 @@ export class CellarClient {
       total: citations.length,
     };
   }
+
+  /**
+   * Builds a SPARQL query to find EU legal acts by EuroVoc concept.
+   * Accepts either a label string (resolved via skos:prefLabel) or a direct URI.
+   */
+  buildEurovocQuery(
+    concept: string,
+    resourceType: string,
+    language: string,
+    limit: number
+  ): string {
+    const lang = LANGUAGE_URI_MAP[language] ?? language;
+    const isUri = concept.startsWith('http');
+
+    const conceptFilter = isUri
+      ? `  ?work cdm:work_is_about_concept_eurovoc <${concept}> .`
+      : [
+          `  ?work cdm:work_is_about_concept_eurovoc ?evConcept .`,
+          `  ?evConcept skos:prefLabel ?evLabel .`,
+          `  FILTER(CONTAINS(LCASE(STR(?evLabel)), LCASE("${escapeSparqlString(concept)}")))`,
+        ].join('\n');
+
+    const typeFilter = resourceType !== 'any'
+      ? `  ?work cdm:work_has_resource-type <http://publications.europa.eu/resource/authority/resource-type/${resourceType}> .`
+      : '';
+
+    return [
+      'PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>',
+      'PREFIX skos: <http://www.w3.org/2004/02/skos/core#>',
+      'PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>',
+      '',
+      'SELECT DISTINCT ?work ?celex ?title ?date ?resType WHERE {',
+      conceptFilter,
+      typeFilter,
+      '  ?work cdm:resource_legal_id_celex ?celex .',
+      '  ?work cdm:work_has_resource-type ?resTypeUri .',
+      '  BIND(REPLACE(STR(?resTypeUri), "^.*/", "") AS ?resType)',
+      `  ?expr cdm:expression_belongs_to_work ?work .`,
+      `  ?expr cdm:expression_uses_language <http://publications.europa.eu/resource/authority/language/${lang}> .`,
+      '  ?expr cdm:expression_title ?title .',
+      '  OPTIONAL { ?work cdm:work_date_document ?date . }',
+      `  FILTER NOT EXISTS { ?work cdm:do_not_index "true"^^xsd:boolean }`,
+      '}',
+      'ORDER BY DESC(?date)',
+      `LIMIT ${limit}`,
+    ].join('\n');
+  }
+
+  /**
+   * Executes a EuroVoc concept query against the SPARQL endpoint and returns search results.
+   */
+  async eurovocQuery(
+    concept: string,
+    resourceType: string,
+    language: string,
+    limit: number
+  ): Promise<SearchResult[]> {
+    const sparql = this.buildEurovocQuery(concept, resourceType, language, limit);
+    const httpLang = LANGUAGE_HTTP_MAP[language] ?? 'de';
+
+    const response = await fetch(SPARQL_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/sparql-query',
+        Accept: 'application/sparql-results+json',
+      },
+      body: sparql,
+    });
+
+    if (!response.ok) {
+      throw new Error(`SPARQL endpoint error: ${response.status}`);
+    }
+
+    const data = (await response.json()) as SparqlResponse;
+    return data.results.bindings.map((b) => ({
+      celex: b.celex.value,
+      title: b.title.value,
+      date: b.date?.value ?? '',
+      type: b.resType.value,
+      eurlex_url: `${EURLEX_BASE}/${httpLang}/TXT/?uri=CELEX:${b.celex.value}`,
+    }));
+  }
 }

--- a/src/services/cellarClient.ts
+++ b/src/services/cellarClient.ts
@@ -459,6 +459,10 @@ export class CellarClient {
     const lang = LANGUAGE_URI_MAP[language] ?? language;
     const isUri = concept.startsWith('http');
 
+    if (isUri && /[><\s"{}|\\^`]/.test(concept)) {
+      throw new Error(`Invalid URI: contains characters not allowed in SPARQL IRIs`);
+    }
+
     const conceptFilter = isUri
       ? `  ?work cdm:work_is_about_concept_eurovoc <${concept}> .`
       : [

--- a/src/tools/eurovoc.ts
+++ b/src/tools/eurovoc.ts
@@ -1,0 +1,50 @@
+import { eurovocSchema } from '../schemas/eurovocSchema.js'
+import { CellarClient } from '../services/cellarClient.js'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+export async function handleEurlexByEurovoc(input: {
+  concept: string
+  resource_type: string
+  language: string
+  limit: number
+}) {
+  try {
+    const parsed = eurovocSchema.parse(input)
+    const client = new CellarClient()
+    const results = await client.eurovocQuery(
+      parsed.concept,
+      parsed.resource_type,
+      parsed.language,
+      parsed.limit
+    )
+
+    if (results.length === 0) {
+      return {
+        content: [{ type: 'text' as const, text: `Keine Ergebnisse für EuroVoc-Konzept "${parsed.concept}"` }],
+      }
+    }
+
+    return {
+      content: [{
+        type: 'text' as const,
+        text: JSON.stringify({ results, total: results.length }),
+      }],
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      content: [{ type: 'text' as const, text: `Error: ${message}` }],
+      isError: true,
+    }
+  }
+}
+
+export function registerEurovocTool(server: McpServer) {
+  server.tool(
+    'eurlex_by_eurovoc',
+    'Sucht EU-Rechtsakte nach EuroVoc-Thema (z.B. "artificial intelligence", "data protection")',
+    eurovocSchema.shape,
+    { readOnlyHint: true, destructiveHint: false },
+    async (params) => handleEurlexByEurovoc(params)
+  )
+}

--- a/tests/cellarClient.eurovoc.test.ts
+++ b/tests/cellarClient.eurovoc.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { CellarClient } from '../src/services/cellarClient.js'
+
+const mockFetch = vi.fn()
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  vi.stubGlobal('fetch', mockFetch)
+})
+
+describe('buildEurovocQuery()', () => {
+  it('E4 – resolves label to EuroVoc concept via skos:prefLabel', () => {
+    const client = new CellarClient()
+    const sparql = client.buildEurovocQuery('artificial intelligence', 'any', 'ENG', 10)
+
+    expect(sparql).toContain('skos:prefLabel')
+    expect(sparql).toContain('artificial intelligence')
+    expect(sparql).toContain('work_is_about_concept_eurovoc')
+  })
+
+  it('E5 – uses URI directly when concept starts with http', () => {
+    const client = new CellarClient()
+    const sparql = client.buildEurovocQuery('http://eurovoc.europa.eu/4424', 'any', 'ENG', 10)
+
+    expect(sparql).toContain('http://eurovoc.europa.eu/4424')
+    expect(sparql).not.toContain('skos:prefLabel')
+  })
+
+  it('E6 – applies resource_type filter when not any', () => {
+    const client = new CellarClient()
+    const sparql = client.buildEurovocQuery('data protection', 'REG', 'DEU', 10)
+
+    expect(sparql).toContain('resource-type/REG')
+  })
+})
+
+describe('eurovocQuery()', () => {
+  it('E7 – returns SearchResult array from SPARQL response', async () => {
+    const response = {
+      results: {
+        bindings: [{
+          work: { type: 'uri', value: 'http://publications.europa.eu/resource/cellar/uuid1' },
+          celex: { type: 'literal', value: '32024R1689' },
+          title: { type: 'literal', value: 'AI Act' },
+          date: { type: 'literal', value: '2024-06-13' },
+          resType: { type: 'literal', value: 'REG' },
+        }],
+      },
+    }
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => response,
+    })
+
+    const client = new CellarClient()
+    const results = await client.eurovocQuery('artificial intelligence', 'any', 'ENG', 10)
+
+    expect(results).toHaveLength(1)
+    expect(results[0].celex).toBe('32024R1689')
+  })
+
+  it('E8 – returns empty array when no results', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: { bindings: [] } }),
+    })
+
+    const client = new CellarClient()
+    const results = await client.eurovocQuery('xyznonexistent', 'any', 'DEU', 10)
+    expect(results).toEqual([])
+  })
+})

--- a/tests/cellarClient.eurovoc.test.ts
+++ b/tests/cellarClient.eurovoc.test.ts
@@ -32,6 +32,25 @@ describe('buildEurovocQuery()', () => {
 
     expect(sparql).toContain('resource-type/REG')
   })
+
+  it('E12 – rejects URI with SPARQL injection characters', () => {
+    const client = new CellarClient()
+    const maliciousUri = 'http://evil.example.org/concept> . ?x ?y ?z . <http://foo'
+
+    // The method should throw when the URI contains characters that could break
+    // out of the <...> angle-bracket syntax and inject arbitrary SPARQL
+    expect(() => {
+      client.buildEurovocQuery(maliciousUri, 'any', 'ENG', 10)
+    }).toThrow()
+  })
+
+  it('E13 – escapes SPARQL injection characters in concept label', () => {
+    const client = new CellarClient()
+    const sparql = client.buildEurovocQuery('data "protection', 'any', 'ENG', 10)
+
+    expect(sparql).toContain('data \\"protection')
+    expect(sparql).not.toContain('data "protection')
+  })
 })
 
 describe('eurovocQuery()', () => {

--- a/tests/eurovoc.tool.test.ts
+++ b/tests/eurovoc.tool.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockEurovocQuery = vi.fn()
+vi.mock('../src/services/cellarClient.js', () => ({
+  CellarClient: vi.fn().mockImplementation(() => ({
+    eurovocQuery: mockEurovocQuery,
+  })),
+}))
+
+import { handleEurlexByEurovoc } from '../src/tools/eurovoc.js'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('handleEurlexByEurovoc()', () => {
+  it('E9 – returns search results as JSON', async () => {
+    mockEurovocQuery.mockResolvedValueOnce([
+      { celex: '32024R1689', title: 'AI Act', date: '2024-06-13', type: 'REG', eurlex_url: 'https://...' },
+    ])
+
+    const result = await handleEurlexByEurovoc({
+      concept: 'artificial intelligence',
+      resource_type: 'any',
+      language: 'ENG',
+      limit: 10,
+    })
+
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed.results).toHaveLength(1)
+    expect(parsed.total).toBe(1)
+  })
+
+  it('E10 – returns no-results message when empty', async () => {
+    mockEurovocQuery.mockResolvedValueOnce([])
+
+    const result = await handleEurlexByEurovoc({
+      concept: 'xyznonexistent',
+      resource_type: 'any',
+      language: 'DEU',
+      limit: 10,
+    })
+
+    expect(result.content[0].text).toContain('Keine Ergebnisse')
+  })
+
+  it('E11 – returns isError on failure', async () => {
+    mockEurovocQuery.mockRejectedValueOnce(new Error('timeout'))
+
+    const result = await handleEurlexByEurovoc({
+      concept: 'test',
+      resource_type: 'any',
+      language: 'DEU',
+      limit: 10,
+    })
+
+    expect(result.isError).toBe(true)
+  })
+})

--- a/tests/eurovocSchema.test.ts
+++ b/tests/eurovocSchema.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { eurovocSchema } from '../src/schemas/eurovocSchema.js'
+
+describe('eurovocSchema', () => {
+  it('E1 – accepts concept label with defaults', () => {
+    const result = eurovocSchema.parse({ concept: 'artificial intelligence' })
+    expect(result.concept).toBe('artificial intelligence')
+    expect(result.resource_type).toBe('any')
+    expect(result.language).toBe('DEU')
+    expect(result.limit).toBe(10)
+  })
+
+  it('E2 – accepts concept as EuroVoc URI', () => {
+    const result = eurovocSchema.parse({ concept: 'http://eurovoc.europa.eu/4424' })
+    expect(result.concept).toBe('http://eurovoc.europa.eu/4424')
+  })
+
+  it('E3 – requires concept min 2 chars', () => {
+    expect(() => eurovocSchema.parse({ concept: 'a' })).toThrow()
+  })
+})

--- a/tests/eval/phase4-server.eval.test.ts
+++ b/tests/eval/phase4-server.eval.test.ts
@@ -51,15 +51,15 @@ describe('Phase 4 Eval – Server', () => {
     expect(server1).not.toBe(server2)
   })
 
-  it('server registers exactly 4 tools: eurlex_citations, eurlex_search, eurlex_fetch, eurlex_metadata', async () => {
+  it('server registers exactly 5 tools: eurlex_by_eurovoc, eurlex_citations, eurlex_search, eurlex_fetch, eurlex_metadata', async () => {
     const pair = await createTestPair()
     pairs.push(pair)
 
     const { tools } = await pair.client.listTools()
     const toolNames = tools.map((t) => t.name).sort()
 
-    expect(tools).toHaveLength(4)
-    expect(toolNames).toEqual(['eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+    expect(tools).toHaveLength(5)
+    expect(toolNames).toEqual(['eurlex_by_eurovoc', 'eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
   })
 
   it('eurlex_search has annotations readOnlyHint=true, destructiveHint=false', async () => {

--- a/tests/eval/phase5-validation.eval.test.ts
+++ b/tests/eval/phase5-validation.eval.test.ts
@@ -312,7 +312,7 @@ describe('Phase 5 Eval – Validation Matrix', () => {
       const { tools } = await pair.client.listTools()
       const toolNames = tools.map((t) => t.name).sort()
 
-      expect(toolNames).toEqual(['eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+      expect(toolNames).toEqual(['eurlex_by_eurovoc', 'eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
     })
 
     it('V20: two createServer calls return different instances', async () => {
@@ -326,8 +326,8 @@ describe('Phase 5 Eval – Validation Matrix', () => {
       const { tools: tools1 } = await pair1.client.listTools()
       const { tools: tools2 } = await pair2.client.listTools()
 
-      expect(tools1.map((t) => t.name).sort()).toEqual(['eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
-      expect(tools2.map((t) => t.name).sort()).toEqual(['eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+      expect(tools1.map((t) => t.name).sort()).toEqual(['eurlex_by_eurovoc', 'eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+      expect(tools2.map((t) => t.name).sort()).toEqual(['eurlex_by_eurovoc', 'eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
     })
 
     it('V22: listPrompts returns eurlex_guide', async () => {

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -55,7 +55,7 @@ describe('Phase 5 – Smoke Tests', () => {
     const { tools } = await pair.client.listTools()
     const toolNames = tools.map((t) => t.name).sort()
 
-    expect(toolNames).toEqual(['eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+    expect(toolNames).toEqual(['eurlex_by_eurovoc', 'eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
   })
 
   // V20: Session-Management → factory creates independent servers per call
@@ -68,8 +68,8 @@ describe('Phase 5 – Smoke Tests', () => {
     const { tools: tools1 } = await pair1.client.listTools()
     const { tools: tools2 } = await pair2.client.listTools()
 
-    expect(tools1.map((t) => t.name).sort()).toEqual(['eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
-    expect(tools2.map((t) => t.name).sort()).toEqual(['eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+    expect(tools1.map((t) => t.name).sort()).toEqual(['eurlex_by_eurovoc', 'eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+    expect(tools2.map((t) => t.name).sort()).toEqual(['eurlex_by_eurovoc', 'eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
 
     // They should be distinct object instances
     expect(pair1.server).not.toBe(pair2.server)
@@ -110,6 +110,18 @@ describe('Phase 5 – Smoke Tests', () => {
     expect(metadata?.annotations).toBeDefined()
     expect(metadata?.annotations?.readOnlyHint).toBe(true)
     expect(metadata?.annotations?.destructiveHint).toBe(false)
+  })
+
+  it('eurlex_by_eurovoc has annotations readOnlyHint=true, destructiveHint=false', async () => {
+    const pair = await createTestPair()
+    pairs.push(pair)
+
+    const { tools } = await pair.client.listTools()
+    const eurovoc = tools.find((t) => t.name === 'eurlex_by_eurovoc')
+
+    expect(eurovoc?.annotations).toBeDefined()
+    expect(eurovoc?.annotations?.readOnlyHint).toBe(true)
+    expect(eurovoc?.annotations?.destructiveHint).toBe(false)
   })
 
   it('eurlex_citations has annotations readOnlyHint=true, destructiveHint=false', async () => {


### PR DESCRIPTION
## Summary
- Adds `eurlex_by_eurovoc` tool — thematic search for EU legal acts via EuroVoc taxonomy classification
- Accepts human-readable labels (`"artificial intelligence"`) or direct EuroVoc URIs (`http://eurovoc.europa.eu/4424`)
- Returns same `SearchResult[]` format as `eurlex_search` for consistency

## Implementation
- `eurovocSchema` (Zod): validates `concept` (2-500 chars), `resource_type`, `language`, `limit`
- `buildEurovocQuery()`: two SPARQL paths — label→`skos:prefLabel` CONTAINS lookup vs direct URI binding
- `eurovocQuery()`: executes SPARQL against Cellar endpoint, returns `SearchResult[]`
- `do_not_index` filter excludes non-indexable documents
- Tool registered as 5th tool in MCP server

## Test plan
- [x] 3 schema tests (E1-E3): defaults, URI acceptance, min-length validation
- [x] 3 SPARQL builder tests (E4-E6): label path, URI path, resource_type filter
- [x] 2 query executor tests (E7-E8): result mapping, empty results
- [x] 3 tool handler tests (E9-E11): JSON response, no-results message, error handling
- [x] Smoke tests updated for 5 tools
- [x] Full suite: 176/176 tests passing

Closes #3