### PR TITLE
Add eurlex_consolidated tool for consolidated EU legal acts via ELI

### DIFF
--- a/docs/superpowers/plans/2026-03-10-new-tools-expansion.md
+++ b/docs/superpowers/plans/2026-03-10-new-tools-expansion.md
@@ -1526,12 +1526,21 @@ git commit -m "feat(eurovoc): add eurlex_by_eurovoc tool with handler and regist
 
 ## Chunk 4: Phase 10 — eurlex_consolidated Tool
 
-### Task 10.1: Zod schema + CellarClient.fetchConsolidated()
+> **Plan Review 2026-03-11:** Optimierungen nach Issue-Analyse angewandt:
+> 1. `LANGUAGE_ELI_MAP` Konstante statt Inline-Ternaries
+> 2. `ConsolidatedResult` Interface in `src/types.ts`
+> 3. Spezifische 404-Fehlermeldung mit Hinweis auf `eurlex_fetch`
+> 4. `redirect: 'follow'` explizit dokumentiert
+> 5. `Accept: text/html` Header (unterscheidet sich von fetchDocument)
+> 6. Smoke-Test mit vollständiger alphabetischer Tool-Liste
+
+### Task 10.1: Zod schema + ConsolidatedResult type + CellarClient.fetchConsolidated()
 
 **Files:**
+- Modify: `src/types.ts` — Add ConsolidatedResult interface
+- Modify: `src/services/cellarClient.ts` — Add LANGUAGE_ELI_MAP + fetchConsolidated()
 - Create: `src/schemas/consolidatedSchema.ts`
 - Create: `tests/consolidatedSchema.test.ts`
-- Modify: `src/services/cellarClient.ts`
 - Create: `tests/cellarClient.consolidated.test.ts`
 
 - [ ] **Step 1: Write the failing test for schema**
@@ -1565,7 +1574,24 @@ describe('consolidatedSchema', () => {
 Run: `pnpm vitest run tests/consolidatedSchema.test.ts`
 Expected: FAIL
 
-- [ ] **Step 3: Create consolidatedSchema**
+- [ ] **Step 3: Add ConsolidatedResult type to src/types.ts**
+
+In `src/types.ts`, append:
+
+```typescript
+export interface ConsolidatedResult {
+  doc_type: string
+  year: number
+  number: number
+  language: string
+  content: string
+  truncated: boolean
+  char_count: number
+  eli_url: string
+}
+```
+
+- [ ] **Step 4: Create consolidatedSchema**
 
 Create `src/schemas/consolidatedSchema.ts`:
 
@@ -1592,12 +1618,25 @@ export const consolidatedSchema = z.object({
 export type ConsolidatedInput = z.infer<typeof consolidatedSchema>
 ```
 
-- [ ] **Step 4: Run schema test**
+- [ ] **Step 5: Run schema test**
 
 Run: `pnpm vitest run tests/consolidatedSchema.test.ts`
 Expected: PASS
 
-- [ ] **Step 5: Write the failing test for fetchConsolidated**
+- [ ] **Step 6: Add LANGUAGE_ELI_MAP to CellarClient**
+
+In `src/services/cellarClient.ts`, add after `LANGUAGE_HTTP_MAP`:
+
+```typescript
+/** Maps 3-letter language codes to ELI URL language codes (ISO 639-3) */
+const LANGUAGE_ELI_MAP: Record<string, string> = {
+  DEU: 'deu',
+  ENG: 'eng',
+  FRA: 'fra',
+};
+```
+
+- [ ] **Step 7: Write the failing test for fetchConsolidated**
 
 Create `tests/cellarClient.consolidated.test.ts`:
 
@@ -1640,24 +1679,25 @@ describe('fetchConsolidated()', () => {
     expect(result).toContain('Artikel 1')
   })
 
-  it('CO6 – throws on 404', async () => {
+  it('CO6 – throws specific message on 404 with eurlex_fetch hint', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 404,
     })
 
     const client = new CellarClient()
-    await expect(client.fetchConsolidated('reg', 9999, 9999, 'DEU')).rejects.toThrow()
+    await expect(client.fetchConsolidated('reg', 9999, 9999, 'DEU'))
+      .rejects.toThrow(/eurlex_fetch/)
   })
 })
 ```
 
-- [ ] **Step 6: Run test to verify it fails**
+- [ ] **Step 8: Run test to verify it fails**
 
 Run: `pnpm vitest run tests/cellarClient.consolidated.test.ts`
 Expected: FAIL
 
-- [ ] **Step 7: Implement fetchConsolidated()**
+- [ ] **Step 9: Implement fetchConsolidated()**
 
 Add to CellarClient class:
 
@@ -1668,29 +1708,35 @@ Add to CellarClient class:
     number: number,
     language: string
   ): Promise<string> {
-    const langCode = LANGUAGE_HTTP_MAP[language] ?? 'de'
-    const eliUrl = `http://data.europa.eu/eli/${docType}/${year}/${number}/oj/${langCode === 'de' ? 'deu' : langCode === 'en' ? 'eng' : 'fra'}/xhtml`
+    const eliLang = LANGUAGE_ELI_MAP[language] ?? 'deu'
+    const eliUrl = `http://data.europa.eu/eli/${docType}/${year}/${number}/oj/${eliLang}/xhtml`
 
     const response = await fetch(eliUrl, {
       method: 'GET',
       headers: { Accept: 'text/html' },
-      redirect: 'follow',
+      redirect: 'follow',  // ELI URLs redirect to EUR-Lex
     })
 
     if (!response.ok) {
-      throw new Error(`Consolidated document not found: ${docType}/${year}/${number} (HTTP ${response.status})`)
+      if (response.status === 404) {
+        throw new Error(
+          `Keine konsolidierte Fassung für ${docType}/${year}/${number} verfügbar. ` +
+          `Verwenden Sie eurlex_fetch mit der CELEX-ID für die Original-OJ-Version.`
+        )
+      }
+      throw new Error(`Consolidated document error: ${docType}/${year}/${number} (HTTP ${response.status})`)
     }
 
     return response.text()
   }
 ```
 
-- [ ] **Step 8: Run test to verify it passes**
+- [ ] **Step 10: Run test to verify it passes**
 
 Run: `pnpm vitest run tests/cellarClient.consolidated.test.ts`
 Expected: PASS
 
-- [ ] **Step 9: Commit**
+- [ ] **Step 11: Commit**
 
 ```bash
 git add src/schemas/consolidatedSchema.ts src/services/cellarClient.ts tests/consolidatedSchema.test.ts tests/cellarClient.consolidated.test.ts
@@ -1810,6 +1856,7 @@ Create `src/tools/consolidated.ts`:
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { CellarClient } from '../services/cellarClient.js'
 import { consolidatedSchema } from '../schemas/consolidatedSchema.js'
+import type { ConsolidatedResult } from '../types.js'
 
 export async function handleEurlexConsolidated(input: {
   doc_type: string
@@ -1903,10 +1950,14 @@ git commit -m "feat(consolidated): add eurlex_consolidated tool with ELI-based r
 ```
 
 **Definition of Done Phase 10:**
-- [ ] `consolidatedSchema` validates doc_type, year, number, language, format, max_chars
-- [ ] `CellarClient.fetchConsolidated()` fetches via ELI URL
+- [ ] `ConsolidatedResult` interface in `src/types.ts`
+- [ ] `LANGUAGE_ELI_MAP` constant in `cellarClient.ts` (no inline ternaries)
+- [ ] `consolidatedSchema` validates doc_type, year (1950-2100), number, language, format, max_chars
+- [ ] `CellarClient.fetchConsolidated()` fetches via ELI URL with `redirect: 'follow'` + `Accept: text/html`
+- [ ] Spezifische 404-Fehlermeldung mit Hinweis auf `eurlex_fetch`
 - [ ] Tool handler applies format conversion + truncation (same pattern as eurlex_fetch)
 - [ ] Tool registered as `eurlex_consolidated`
+- [ ] Smoke test updated (6 Tools, alphabetisch: `eurlex_by_eurovoc, eurlex_citations, eurlex_consolidated, eurlex_fetch, eurlex_metadata, eurlex_search`)
 - [ ] 7+ new unit tests, all green
 
 ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { registerFetchTool } from './tools/fetch.js'
 import { registerMetadataTool } from './tools/metadata.js'
 import { registerCitationsTool } from './tools/citations.js'
 import { registerEurovocTool } from './tools/eurovoc.js'
+import { registerConsolidatedTool } from './tools/consolidated.js'
 import { registerGuidePrompt } from './prompts/guide.js'
 
 // ---------------------------------------------------------------------------
@@ -26,6 +27,7 @@ export function createServer(): McpServer {
   registerMetadataTool(server)
   registerCitationsTool(server)
   registerEurovocTool(server)
+  registerConsolidatedTool(server)
   registerGuidePrompt(server)
 
   return server

--- a/src/schemas/consolidatedSchema.ts
+++ b/src/schemas/consolidatedSchema.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+
+export const consolidatedSchema = z.object({
+  doc_type: z.enum(['reg', 'dir', 'dec'])
+    .describe("Dokumenttyp: reg=Verordnung, dir=Richtlinie, dec=Entscheidung"),
+  year: z.number().int().min(1950).max(2100)
+    .describe("Jahr des Rechtsakts, z.B. 2024"),
+  number: z.number().int().min(1)
+    .describe("Dokumentnummer, z.B. 1689"),
+  language: z.enum(['DEU', 'ENG', 'FRA'])
+    .default('DEU')
+    .describe('Sprache'),
+  format: z.enum(['xhtml', 'plain'])
+    .default('xhtml')
+    .describe('Ausgabeformat'),
+  max_chars: z.number().int().min(1000).max(50000).default(20000)
+    .describe('Maximale Zeichenanzahl'),
+}).strict()
+
+export type ConsolidatedInput = z.infer<typeof consolidatedSchema>

--- a/src/services/cellarClient.ts
+++ b/src/services/cellarClient.ts
@@ -547,7 +547,7 @@ export class CellarClient {
     year: number,
     number: number,
     language: string
-  ): Promise<string> {
+  ): Promise<{ content: string; eliUrl: string }> {
     const eliLang = LANGUAGE_ELI_MAP[language] ?? 'deu'
     const eliUrl = `http://data.europa.eu/eli/${docType}/${year}/${number}/${eliLang}/xhtml`
 
@@ -567,6 +567,6 @@ export class CellarClient {
       throw new Error(`Consolidated document error: ${docType}/${year}/${number} (HTTP ${response.status})`)
     }
 
-    return response.text()
+    return { content: await response.text(), eliUrl }
   }
 }

--- a/src/services/cellarClient.ts
+++ b/src/services/cellarClient.ts
@@ -21,6 +21,13 @@ const LANGUAGE_HTTP_MAP: Record<string, string> = {
   FRA: 'fr',
 };
 
+/** Maps 3-letter language codes to ELI URL language codes (ISO 639-3) */
+const LANGUAGE_ELI_MAP: Record<string, string> = {
+  DEU: 'deu',
+  ENG: 'eng',
+  FRA: 'fra',
+};
+
 /** Shape of a single SPARQL binding value */
 interface SparqlBindingValue {
   type: string;
@@ -530,5 +537,36 @@ export class CellarClient {
       type: b.resType.value,
       eurlex_url: `${EURLEX_BASE}/${httpLang}/TXT/?uri=CELEX:${b.celex.value}`,
     }));
+  }
+
+  /**
+   * Fetches the consolidated (currently applicable) version of an EU legal act via ELI URL.
+   */
+  async fetchConsolidated(
+    docType: string,
+    year: number,
+    number: number,
+    language: string
+  ): Promise<string> {
+    const eliLang = LANGUAGE_ELI_MAP[language] ?? 'deu'
+    const eliUrl = `http://data.europa.eu/eli/${docType}/${year}/${number}/${eliLang}/xhtml`
+
+    const response = await fetch(eliUrl, {
+      method: 'GET',
+      headers: { Accept: 'application/xhtml+xml' },
+      redirect: 'follow',  // ELI URLs redirect to EUR-Lex
+    })
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        throw new Error(
+          `Keine konsolidierte Fassung für ${docType}/${year}/${number} verfügbar. ` +
+          `Verwenden Sie eurlex_fetch mit der CELEX-ID für die Original-OJ-Version.`
+        )
+      }
+      throw new Error(`Consolidated document error: ${docType}/${year}/${number} (HTTP ${response.status})`)
+    }
+
+    return response.text()
   }
 }

--- a/src/tools/consolidated.ts
+++ b/src/tools/consolidated.ts
@@ -1,5 +1,6 @@
 import { consolidatedSchema } from '../schemas/consolidatedSchema.js'
 import { CellarClient } from '../services/cellarClient.js'
+import type { ConsolidatedResult } from '../types.js'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
 export async function handleEurlexConsolidated(input: {
@@ -31,20 +32,22 @@ export async function handleEurlexConsolidated(input: {
       content = content.slice(0, parsed.max_chars)
     }
 
+    const result: ConsolidatedResult = {
+      doc_type: parsed.doc_type,
+      year: parsed.year,
+      number: parsed.number,
+      language: parsed.language,
+      content,
+      truncated,
+      char_count: content.length,
+      eli_url: eliUrl,
+    }
+
     return {
       content: [
         {
           type: 'text' as const,
-          text: JSON.stringify({
-            doc_type: parsed.doc_type,
-            year: parsed.year,
-            number: parsed.number,
-            language: parsed.language,
-            content,
-            truncated,
-            char_count: content.length,
-            eli_url: eliUrl,
-          }),
+          text: JSON.stringify(result),
         },
       ],
     }

--- a/src/tools/consolidated.ts
+++ b/src/tools/consolidated.ts
@@ -2,8 +2,6 @@ import { consolidatedSchema } from '../schemas/consolidatedSchema.js'
 import { CellarClient } from '../services/cellarClient.js'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
-const ELI_LANG: Record<string, string> = { DEU: 'deu', ENG: 'eng', FRA: 'fra' }
-
 export async function handleEurlexConsolidated(input: {
   doc_type: string
   year: number
@@ -16,13 +14,14 @@ export async function handleEurlexConsolidated(input: {
     const parsed = consolidatedSchema.parse(input)
 
     const client = new CellarClient()
-    let content = await client.fetchConsolidated(
+    const { content: rawContent, eliUrl } = await client.fetchConsolidated(
       parsed.doc_type,
       parsed.year,
       parsed.number,
       parsed.language
     )
 
+    let content = rawContent
     if (parsed.format === 'plain') {
       content = content.replace(/<[^>]*>/g, '')
     }
@@ -44,7 +43,7 @@ export async function handleEurlexConsolidated(input: {
             content,
             truncated,
             char_count: content.length,
-            eli_url: `http://data.europa.eu/eli/${parsed.doc_type}/${parsed.year}/${parsed.number}/${ELI_LANG[parsed.language] ?? 'deu'}/xhtml`,
+            eli_url: eliUrl,
           }),
         },
       ],

--- a/src/tools/consolidated.ts
+++ b/src/tools/consolidated.ts
@@ -1,0 +1,69 @@
+import { consolidatedSchema } from '../schemas/consolidatedSchema.js'
+import { CellarClient } from '../services/cellarClient.js'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+const ELI_LANG: Record<string, string> = { DEU: 'deu', ENG: 'eng', FRA: 'fra' }
+
+export async function handleEurlexConsolidated(input: {
+  doc_type: string
+  year: number
+  number: number
+  language: string
+  format: string
+  max_chars: number
+}) {
+  try {
+    const parsed = consolidatedSchema.parse(input)
+
+    const client = new CellarClient()
+    let content = await client.fetchConsolidated(
+      parsed.doc_type,
+      parsed.year,
+      parsed.number,
+      parsed.language
+    )
+
+    if (parsed.format === 'plain') {
+      content = content.replace(/<[^>]*>/g, '')
+    }
+
+    const truncated = content.length > parsed.max_chars
+    if (truncated) {
+      content = content.slice(0, parsed.max_chars)
+    }
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            doc_type: parsed.doc_type,
+            year: parsed.year,
+            number: parsed.number,
+            language: parsed.language,
+            content,
+            truncated,
+            char_count: content.length,
+            eli_url: `http://data.europa.eu/eli/${parsed.doc_type}/${parsed.year}/${parsed.number}/${ELI_LANG[parsed.language] ?? 'deu'}/xhtml`,
+          }),
+        },
+      ],
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      content: [{ type: 'text' as const, text: `Error: ${message}` }],
+      isError: true,
+    }
+  }
+}
+
+export function registerConsolidatedTool(server: McpServer) {
+  server.tool(
+    'eurlex_consolidated',
+    'Ruft die konsolidierte (aktuell gültige) Fassung eines EU-Rechtsakts ab via ELI',
+    consolidatedSchema.shape,
+    { readOnlyHint: true, destructiveHint: false },
+    async (params) => handleEurlexConsolidated(params)
+  )
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,3 +60,14 @@ export interface CitationsResult {
   citations: CitationEntry[]
   total: number
 }
+
+export interface ConsolidatedResult {
+  doc_type: string
+  year: number
+  number: number
+  language: string
+  content: string
+  truncated: boolean
+  char_count: number
+  eli_url: string
+}

--- a/tests/cellarClient.consolidated.test.ts
+++ b/tests/cellarClient.consolidated.test.ts
@@ -27,7 +27,7 @@ describe('fetchConsolidated()', () => {
     expect((opts.headers as Record<string, string>).Accept).toBe('application/xhtml+xml')
   })
 
-  it('CO5 – returns HTML content string', async () => {
+  it('CO5 – returns content and eliUrl', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       text: async () => '<html><body>Artikel 1</body></html>',
@@ -36,7 +36,8 @@ describe('fetchConsolidated()', () => {
     const client = new CellarClient()
     const result = await client.fetchConsolidated('dir', 2022, 2555, 'DEU')
 
-    expect(result).toContain('Artikel 1')
+    expect(result.content).toContain('Artikel 1')
+    expect(result.eliUrl).toContain('data.europa.eu/eli/dir/2022/2555/deu/xhtml')
   })
 
   it('CO6 – throws specific message on 404 with eurlex_fetch hint', async () => {

--- a/tests/cellarClient.consolidated.test.ts
+++ b/tests/cellarClient.consolidated.test.ts
@@ -50,4 +50,17 @@ describe('fetchConsolidated()', () => {
     await expect(client.fetchConsolidated('reg', 9999, 9999, 'DEU'))
       .rejects.toThrow(/eurlex_fetch/)
   })
+
+  it('CO6b – defaults to deu for unmapped language code', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => '<html><body>Testo consolidato</body></html>',
+    })
+
+    const client = new CellarClient()
+    await client.fetchConsolidated('reg', 2024, 1689, 'ITA')
+
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/deu/xhtml')
+  })
 })

--- a/tests/cellarClient.consolidated.test.ts
+++ b/tests/cellarClient.consolidated.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { CellarClient } from '../src/services/cellarClient.js'
+
+const mockFetch = vi.fn()
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  vi.stubGlobal('fetch', mockFetch)
+})
+
+describe('fetchConsolidated()', () => {
+  it('CO4 – constructs ELI URL with correct doc_type/year/number', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      redirected: true,
+      url: 'https://eur-lex.europa.eu/legal-content/DE/TXT/HTML/?uri=CELEX:02024R1689-20240801',
+      text: async () => '<html><body>Consolidated text</body></html>',
+    })
+
+    const client = new CellarClient()
+    await client.fetchConsolidated('reg', 2024, 1689, 'DEU')
+
+    const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('data.europa.eu/eli/reg/2024/1689')
+    expect(url).not.toContain('/oj/')
+    expect(url).toContain('/deu/xhtml')
+    expect((opts.headers as Record<string, string>).Accept).toBe('application/xhtml+xml')
+  })
+
+  it('CO5 – returns HTML content string', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => '<html><body>Artikel 1</body></html>',
+    })
+
+    const client = new CellarClient()
+    const result = await client.fetchConsolidated('dir', 2022, 2555, 'DEU')
+
+    expect(result).toContain('Artikel 1')
+  })
+
+  it('CO6 – throws specific message on 404 with eurlex_fetch hint', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    })
+
+    const client = new CellarClient()
+    await expect(client.fetchConsolidated('reg', 9999, 9999, 'DEU'))
+      .rejects.toThrow(/eurlex_fetch/)
+  })
+})

--- a/tests/consolidated.tool.test.ts
+++ b/tests/consolidated.tool.test.ts
@@ -13,9 +13,12 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
+const mockResult = (content: string, eliUrl = 'http://data.europa.eu/eli/reg/2024/1689/deu/xhtml') =>
+  ({ content, eliUrl })
+
 describe('handleEurlexConsolidated()', () => {
   it('CO7 – returns document content with truncation info', async () => {
-    mockFetchConsolidated.mockResolvedValueOnce('<html><body>Content</body></html>')
+    mockFetchConsolidated.mockResolvedValueOnce(mockResult('<html><body>Content</body></html>'))
 
     const result = await handleEurlexConsolidated({
       doc_type: 'reg',
@@ -35,7 +38,7 @@ describe('handleEurlexConsolidated()', () => {
   })
 
   it('CO8 – strips HTML in plain format', async () => {
-    mockFetchConsolidated.mockResolvedValueOnce('<html><body><p>Text</p></body></html>')
+    mockFetchConsolidated.mockResolvedValueOnce(mockResult('<html><body><p>Text</p></body></html>'))
 
     const result = await handleEurlexConsolidated({
       doc_type: 'reg',
@@ -52,7 +55,7 @@ describe('handleEurlexConsolidated()', () => {
   })
 
   it('CO9 – truncates at max_chars', async () => {
-    mockFetchConsolidated.mockResolvedValueOnce('x'.repeat(30000))
+    mockFetchConsolidated.mockResolvedValueOnce(mockResult('x'.repeat(30000)))
 
     const result = await handleEurlexConsolidated({
       doc_type: 'reg',

--- a/tests/consolidated.tool.test.ts
+++ b/tests/consolidated.tool.test.ts
@@ -8,6 +8,7 @@ vi.mock('../src/services/cellarClient.js', () => ({
 }))
 
 import { handleEurlexConsolidated } from '../src/tools/consolidated.js'
+import type { ConsolidatedResult } from '../src/types.js'
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -69,6 +70,35 @@ describe('handleEurlexConsolidated()', () => {
     const parsed = JSON.parse(result.content[0].text)
     expect(parsed.truncated).toBe(true)
     expect(parsed.char_count).toBeLessThanOrEqual(5000)
+  })
+
+  it('CO-TYPE – result satisfies ConsolidatedResult shape', async () => {
+    mockFetchConsolidated.mockResolvedValueOnce(mockResult('<html><body>Content</body></html>'))
+
+    const result = await handleEurlexConsolidated({
+      doc_type: 'reg',
+      year: 2024,
+      number: 1689,
+      language: 'DEU',
+      format: 'xhtml',
+      max_chars: 20000,
+    })
+
+    const parsed: ConsolidatedResult = JSON.parse(result.content[0].text)
+    const requiredKeys: (keyof ConsolidatedResult)[] = [
+      'doc_type', 'year', 'number', 'language', 'content', 'truncated', 'char_count', 'eli_url',
+    ]
+    for (const key of requiredKeys) {
+      expect(parsed).toHaveProperty(key)
+    }
+    expect(typeof parsed.doc_type).toBe('string')
+    expect(typeof parsed.year).toBe('number')
+    expect(typeof parsed.number).toBe('number')
+    expect(typeof parsed.language).toBe('string')
+    expect(typeof parsed.content).toBe('string')
+    expect(typeof parsed.truncated).toBe('boolean')
+    expect(typeof parsed.char_count).toBe('number')
+    expect(typeof parsed.eli_url).toBe('string')
   })
 
   it('CO10 – returns isError on failure', async () => {

--- a/tests/consolidated.tool.test.ts
+++ b/tests/consolidated.tool.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockFetchConsolidated = vi.fn()
+vi.mock('../src/services/cellarClient.js', () => ({
+  CellarClient: vi.fn().mockImplementation(() => ({
+    fetchConsolidated: mockFetchConsolidated,
+  })),
+}))
+
+import { handleEurlexConsolidated } from '../src/tools/consolidated.js'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('handleEurlexConsolidated()', () => {
+  it('CO7 – returns document content with truncation info', async () => {
+    mockFetchConsolidated.mockResolvedValueOnce('<html><body>Content</body></html>')
+
+    const result = await handleEurlexConsolidated({
+      doc_type: 'reg',
+      year: 2024,
+      number: 1689,
+      language: 'DEU',
+      format: 'xhtml',
+      max_chars: 20000,
+    })
+
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed.content).toContain('Content')
+    expect(parsed.truncated).toBe(false)
+    expect(parsed.eli_url).toContain('data.europa.eu/eli/reg/2024/1689')
+    expect(parsed.eli_url).not.toContain('/oj/')
+    expect(parsed.eli_url).toContain('/deu/xhtml')
+  })
+
+  it('CO8 – strips HTML in plain format', async () => {
+    mockFetchConsolidated.mockResolvedValueOnce('<html><body><p>Text</p></body></html>')
+
+    const result = await handleEurlexConsolidated({
+      doc_type: 'reg',
+      year: 2024,
+      number: 1689,
+      language: 'DEU',
+      format: 'plain',
+      max_chars: 20000,
+    })
+
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed.content).not.toContain('<')
+    expect(parsed.content).toContain('Text')
+  })
+
+  it('CO9 – truncates at max_chars', async () => {
+    mockFetchConsolidated.mockResolvedValueOnce('x'.repeat(30000))
+
+    const result = await handleEurlexConsolidated({
+      doc_type: 'reg',
+      year: 2024,
+      number: 1689,
+      language: 'DEU',
+      format: 'xhtml',
+      max_chars: 5000,
+    })
+
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed.truncated).toBe(true)
+    expect(parsed.char_count).toBeLessThanOrEqual(5000)
+  })
+
+  it('CO10 – returns isError on failure', async () => {
+    mockFetchConsolidated.mockRejectedValueOnce(new Error('Not found'))
+
+    const result = await handleEurlexConsolidated({
+      doc_type: 'reg',
+      year: 9999,
+      number: 9999,
+      language: 'DEU',
+      format: 'xhtml',
+      max_chars: 20000,
+    })
+
+    expect(result.isError).toBe(true)
+  })
+})

--- a/tests/consolidatedSchema.test.ts
+++ b/tests/consolidatedSchema.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { consolidatedSchema } from '../src/schemas/consolidatedSchema.js'
+
+describe('consolidatedSchema', () => {
+  it('CO1 – accepts type/year/number with defaults', () => {
+    const result = consolidatedSchema.parse({ doc_type: 'reg', year: 2024, number: 1689 })
+    expect(result.language).toBe('DEU')
+    expect(result.format).toBe('xhtml')
+  })
+
+  it('CO2 – accepts dir type', () => {
+    const result = consolidatedSchema.parse({ doc_type: 'dir', year: 2022, number: 2555 })
+    expect(result.doc_type).toBe('dir')
+  })
+
+  it('CO3 – rejects year below 1950', () => {
+    expect(() => consolidatedSchema.parse({ doc_type: 'reg', year: 1900, number: 1 })).toThrow()
+  })
+})

--- a/tests/eval/phase4-server.eval.test.ts
+++ b/tests/eval/phase4-server.eval.test.ts
@@ -58,8 +58,8 @@ describe('Phase 4 Eval – Server', () => {
     const { tools } = await pair.client.listTools()
     const toolNames = tools.map((t) => t.name).sort()
 
-    expect(tools).toHaveLength(5)
-    expect(toolNames).toEqual(['eurlex_by_eurovoc', 'eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+    expect(tools).toHaveLength(6)
+    expect(toolNames).toEqual(['eurlex_by_eurovoc', 'eurlex_citations', 'eurlex_consolidated', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
   })
 
   it('eurlex_search has annotations readOnlyHint=true, destructiveHint=false', async () => {

--- a/tests/eval/phase5-validation.eval.test.ts
+++ b/tests/eval/phase5-validation.eval.test.ts
@@ -312,7 +312,7 @@ describe('Phase 5 Eval – Validation Matrix', () => {
       const { tools } = await pair.client.listTools()
       const toolNames = tools.map((t) => t.name).sort()
 
-      expect(toolNames).toEqual(['eurlex_by_eurovoc', 'eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+      expect(toolNames).toEqual(['eurlex_by_eurovoc', 'eurlex_citations', 'eurlex_consolidated', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
     })
 
     it('V20: two createServer calls return different instances', async () => {
@@ -326,8 +326,8 @@ describe('Phase 5 Eval – Validation Matrix', () => {
       const { tools: tools1 } = await pair1.client.listTools()
       const { tools: tools2 } = await pair2.client.listTools()
 
-      expect(tools1.map((t) => t.name).sort()).toEqual(['eurlex_by_eurovoc', 'eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
-      expect(tools2.map((t) => t.name).sort()).toEqual(['eurlex_by_eurovoc', 'eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+      expect(tools1.map((t) => t.name).sort()).toEqual(['eurlex_by_eurovoc', 'eurlex_citations', 'eurlex_consolidated', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+      expect(tools2.map((t) => t.name).sort()).toEqual(['eurlex_by_eurovoc', 'eurlex_citations', 'eurlex_consolidated', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
     })
 
     it('V22: listPrompts returns eurlex_guide', async () => {

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -55,7 +55,7 @@ describe('Phase 5 – Smoke Tests', () => {
     const { tools } = await pair.client.listTools()
     const toolNames = tools.map((t) => t.name).sort()
 
-    expect(toolNames).toEqual(['eurlex_by_eurovoc', 'eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+    expect(toolNames).toEqual(['eurlex_by_eurovoc', 'eurlex_citations', 'eurlex_consolidated', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
   })
 
   // V20: Session-Management → factory creates independent servers per call
@@ -68,8 +68,8 @@ describe('Phase 5 – Smoke Tests', () => {
     const { tools: tools1 } = await pair1.client.listTools()
     const { tools: tools2 } = await pair2.client.listTools()
 
-    expect(tools1.map((t) => t.name).sort()).toEqual(['eurlex_by_eurovoc', 'eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
-    expect(tools2.map((t) => t.name).sort()).toEqual(['eurlex_by_eurovoc', 'eurlex_citations', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+    expect(tools1.map((t) => t.name).sort()).toEqual(['eurlex_by_eurovoc', 'eurlex_citations', 'eurlex_consolidated', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
+    expect(tools2.map((t) => t.name).sort()).toEqual(['eurlex_by_eurovoc', 'eurlex_citations', 'eurlex_consolidated', 'eurlex_fetch', 'eurlex_metadata', 'eurlex_search'])
 
     // They should be distinct object instances
     expect(pair1.server).not.toBe(pair2.server)
@@ -134,6 +134,18 @@ describe('Phase 5 – Smoke Tests', () => {
     expect(citations?.annotations).toBeDefined()
     expect(citations?.annotations?.readOnlyHint).toBe(true)
     expect(citations?.annotations?.destructiveHint).toBe(false)
+  })
+
+  it('eurlex_consolidated has annotations readOnlyHint=true, destructiveHint=false', async () => {
+    const pair = await createTestPair()
+    pairs.push(pair)
+
+    const { tools } = await pair.client.listTools()
+    const consolidated = tools.find((t) => t.name === 'eurlex_consolidated')
+
+    expect(consolidated?.annotations).toBeDefined()
+    expect(consolidated?.annotations?.readOnlyHint).toBe(true)
+    expect(consolidated?.annotations?.destructiveHint).toBe(false)
   })
 
   // V22: eurlex_guide Prompt abrufbar → server has eurlex_guide prompt registered


### PR DESCRIPTION
## Summary

- Adds `eurlex_consolidated` tool that fetches the currently applicable (consolidated) version of EU legislation via the European Legislation Identifier (ELI) URL scheme
- Implements `consolidatedSchema` (Zod), `CellarClient.fetchConsolidated()`, and tool handler with format conversion + truncation
- Uses correct ELI path (without `/oj/` segment) to target consolidated rather than original Official Journal versions — verified via Playwright against EUR-Lex

## Details

- `LANGUAGE_ELI_MAP` constant maps 3-letter codes to ISO 639-3 for ELI URLs
- `ConsolidatedResult` interface in `src/types.ts`
- Specific 404 error message with hint to use `eurlex_fetch` for original OJ version
- `fetchConsolidated()` returns `{ content, eliUrl }` to keep ELI URL construction encapsulated in the service layer
- Server now exposes 6 tools (alphabetically: `eurlex_by_eurovoc`, `eurlex_citations`, `eurlex_consolidated`, `eurlex_fetch`, `eurlex_metadata`, `eurlex_search`)

## Test plan

- [x] 11 new unit tests (CO1–CO10 + annotation smoke test), all green
- [x] Full suite: 189/189 tests pass
- [x] Code review agent: 2 critical issues found and fixed (ELI URL path, duplicate language map)
- [x] Simplify review: leaky abstraction fixed by returning eliUrl from service layer

Closes #4