### PR TITLE
Expand resource_type enum and update guide with all 6 tools

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,3 +6,12 @@ export const DEFAULT_LIMIT = 10
 export const MAX_CHARS_DEFAULT = 20000
 export const MAX_CHARS_LIMIT = 50000
 export const REQUEST_TIMEOUT_MS = 30000
+
+export const RESOURCE_TYPES = [
+  'REG', 'REG_IMPL', 'REG_DEL',
+  'DIR', 'DIR_IMPL', 'DIR_DEL',
+  'DEC', 'DEC_IMPL', 'DEC_DEL',
+  'JUDG', 'ORDER', 'OPIN_AG',
+  'RECO',
+  'any',
+] as const

--- a/src/prompts/guide.ts
+++ b/src/prompts/guide.ts
@@ -2,11 +2,32 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 const GUIDE_TEXT = `# EUR-Lex Recherche-Guide
 
+## Verfügbare Tools
+
+### eurlex_search — Titelsuche
+Sucht EU-Rechtsakte nach Titel. Unterstützt Filter nach Typ, Datum, Sprache.
+
+### eurlex_fetch — Volltext abrufen
+Ruft den Volltext eines Rechtsakts per CELEX-ID ab.
+
+### eurlex_metadata — Metadaten abfragen
+Liefert Inkrafttreten, Gültigkeit, In-Kraft-Status, Autoren, EuroVoc-Themen, Directory-Codes.
+
+### eurlex_citations — Zitierungen & Beziehungen
+Findet Zitierungen, Rechtsgrundlagen, Änderungen zu einem Rechtsakt.
+Richtungen: cites (zitiert von), cited_by (zitiert durch), both.
+
+### eurlex_by_eurovoc — Thematische Suche
+Sucht Rechtsakte nach EuroVoc-Konzept. Findet auch Dokumente, die das Stichwort nicht im Titel haben.
+Akzeptiert Labels ("artificial intelligence") oder URIs ("http://eurovoc.europa.eu/4424").
+
+### eurlex_consolidated — Konsolidierte Fassung
+Ruft die aktuell gültige Fassung ab (mit allen Änderungen eingearbeitet) via ELI.
+
 ## CELEX-Nummern-Schema
 - 3 = Sekundärrecht EU (Verordnungen, Richtlinien, Entscheidungen)
 - Danach: Jahr (4-stellig) + Typ-Buchstabe + Dokumentnummer
 - Beispiele: 32024R1689 (AI Act), 32016R0679 (DSGVO), 32022L2555 (NIS2)
-- R = Regulation (Verordnung), L = Richtlinie, D = Entscheidung
 
 ## Typ-Buchstaben → resource_type Mapping
 | CELEX-Buchstabe | resource_type | Bedeutung |
@@ -15,11 +36,26 @@ const GUIDE_TEXT = `# EUR-Lex Recherche-Guide
 | L | DIR | Richtlinie (muss umgesetzt werden) |
 | D | DEC | Entscheidung/Beschluss |
 
+## Erweiterte Typen
+REG_IMPL (Durchführungsverordnung), REG_DEL (Delegierte Verordnung),
+DIR_IMPL (Durchführungsrichtlinie), DIR_DEL (Delegierte Richtlinie),
+DEC_IMPL (Durchführungsbeschluss), DEC_DEL (Delegierter Beschluss),
+RECO (Empfehlung),
+JUDG (Urteil), ORDER (Beschluss), OPIN_AG (Schlussanträge GA)
+
 ## Suchstrategie
-1. eurlex_search sucht NUR in Titeln, nicht im Volltext
-2. Suchbegriffe in der Sprache des Titels verwenden (DE Titel → DE Suchbegriff)
+1. eurlex_search sucht NUR in Titeln → für thematische Suche eurlex_by_eurovoc verwenden
+2. Suchbegriffe in der Sprache des Titels verwenden
 3. Bei Nicht-Treffern: Synonyme probieren ("KI" vs "künstliche Intelligenz")
-4. Bekannte CELEX-ID? → Direkt eurlex_fetch nutzen, Search überspringen
+4. Bekannte CELEX-ID? → Direkt eurlex_fetch oder eurlex_metadata nutzen
+5. Rechtsbeziehungen? → eurlex_citations für Zitierungsketten
+6. Konsolidierte Fassung? → eurlex_consolidated für geltendes Recht
+
+## EuroVoc-Sprachbeispiele
+- Bei language=ENG: "artificial intelligence", "data protection", "cybersecurity"
+- Bei language=DEU: "künstliche Intelligenz", "Datenschutz", "Cybersicherheit"
+- Bei language=FRA: "intelligence artificielle", "protection des données"
+EuroVoc-Labels sind sprachabhängig — passende Sprache zum language-Parameter wählen!
 
 ## Bekannte CELEX-IDs wichtiger Rechtsakte
 - AI Act: 32024R1689
@@ -31,9 +67,11 @@ const GUIDE_TEXT = `# EUR-Lex Recherche-Guide
 - Data Governance Act: 32022R0868
 
 ## Limitations
-- Sehr lange Dokumente (AI Act: ~1.3 MB) werden bei max_chars abgeschnitten
+- Sehr lange Dokumente werden bei max_chars abgeschnitten
 - SPARQL-Antwortzeit: 2-10 Sekunden
-- Nicht alle Dokumente haben eine XHTML-Version`;
+- Nicht alle Dokumente haben eine XHTML-Version
+- EuroVoc-Labels sind sprachabhängig — englische Begriffe bei language=ENG
+- Konsolidierte Fassungen existieren nicht für alle Rechtsakte`;
 
 export function registerGuidePrompt(server: McpServer): void {
   server.prompt("eurlex_guide", {}, () => ({

--- a/src/schemas/eurovocSchema.ts
+++ b/src/schemas/eurovocSchema.ts
@@ -1,9 +1,10 @@
 import { z } from 'zod'
+import { RESOURCE_TYPES } from '../constants.js'
 
 export const eurovocSchema = z.object({
   concept: z.string().min(2).max(500)
     .describe("EuroVoc-Konzept: Label (z.B. 'artificial intelligence') oder URI (z.B. 'http://eurovoc.europa.eu/4424')"),
-  resource_type: z.enum(['REG', 'DIR', 'DEC', 'JUDG', 'any'])
+  resource_type: z.enum(RESOURCE_TYPES)
     .default('any')
     .describe('Dokumenttyp-Filter'),
   language: z.enum(['DEU', 'ENG', 'FRA'])

--- a/src/schemas/searchSchema.ts
+++ b/src/schemas/searchSchema.ts
@@ -3,9 +3,16 @@ import { z } from 'zod'
 export const searchSchema = z.object({
   query: z.string().min(3).max(500)
     .describe("Suchbegriff, z.B. 'artificial intelligence high risk'"),
-  resource_type: z.enum(["REG", "DIR", "DEC", "JUDG", "any"])
+  resource_type: z.enum([
+    "REG", "REG_IMPL", "REG_DEL",
+    "DIR", "DIR_IMPL", "DIR_DEL",
+    "DEC", "DEC_IMPL", "DEC_DEL",
+    "JUDG", "ORDER", "OPIN_AG",
+    "RECO",
+    "any"
+  ])
     .default("any")
-    .describe("Dokumenttyp: REG=Verordnung, DIR=Richtlinie, DEC=Entscheidung, JUDG=Urteil"),
+    .describe("Dokumenttyp: REG=Verordnung, DIR=Richtlinie, DEC=Entscheidung, JUDG=Urteil, REG_IMPL=Durchführungsverordnung, REG_DEL=Delegierte Verordnung, RECO=Empfehlung, ORDER=Gerichtsbeschluss, OPIN_AG=Schlussanträge des Generalanwalts"),
   language: z.enum(["DEU", "ENG", "FRA"])
     .default("DEU")
     .describe("Sprache für Titel und Volltext"),

--- a/src/schemas/searchSchema.ts
+++ b/src/schemas/searchSchema.ts
@@ -1,16 +1,10 @@
 import { z } from 'zod'
+import { RESOURCE_TYPES } from '../constants.js'
 
 export const searchSchema = z.object({
   query: z.string().min(3).max(500)
     .describe("Suchbegriff, z.B. 'artificial intelligence high risk'"),
-  resource_type: z.enum([
-    "REG", "REG_IMPL", "REG_DEL",
-    "DIR", "DIR_IMPL", "DIR_DEL",
-    "DEC", "DEC_IMPL", "DEC_DEL",
-    "JUDG", "ORDER", "OPIN_AG",
-    "RECO",
-    "any"
-  ])
+  resource_type: z.enum(RESOURCE_TYPES)
     .default("any")
     .describe("Dokumenttyp: REG=Verordnung, DIR=Richtlinie, DEC=Entscheidung, JUDG=Urteil, REG_IMPL=Durchführungsverordnung, REG_DEL=Delegierte Verordnung, RECO=Empfehlung, ORDER=Gerichtsbeschluss, OPIN_AG=Schlussanträge des Generalanwalts"),
   language: z.enum(["DEU", "ENG", "FRA"])

--- a/tests/cellarClient.enhanced-search.test.ts
+++ b/tests/cellarClient.enhanced-search.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { searchSchema } from '../src/schemas/searchSchema.js'
+import { CellarClient } from '../src/services/cellarClient.js'
+
+describe('enhanced searchSchema', () => {
+  it('ES1 – accepts REG_IMPL resource type', () => {
+    const result = searchSchema.parse({ query: 'test query', resource_type: 'REG_IMPL' })
+    expect(result.resource_type).toBe('REG_IMPL')
+  })
+
+  it('ES2 – accepts REG_DEL resource type', () => {
+    const result = searchSchema.parse({ query: 'test query', resource_type: 'REG_DEL' })
+    expect(result.resource_type).toBe('REG_DEL')
+  })
+
+  it('ES3 – accepts DIR_IMPL resource type', () => {
+    const result = searchSchema.parse({ query: 'test query', resource_type: 'DIR_IMPL' })
+    expect(result.resource_type).toBe('DIR_IMPL')
+  })
+
+  it('ES4 – accepts RECO resource type', () => {
+    const result = searchSchema.parse({ query: 'test query', resource_type: 'RECO' })
+    expect(result.resource_type).toBe('RECO')
+  })
+})
+
+describe('enhanced buildSparqlQuery()', () => {
+  it('ES5 – generates correct filter for REG_IMPL', () => {
+    const client = new CellarClient()
+    const sparql = client.buildSparqlQuery({
+      query: 'test', resource_type: 'REG_IMPL', language: 'DEU', limit: 10,
+    })
+    expect(sparql).toContain('resource-type/REG_IMPL')
+  })
+})
+
+describe('negative validation', () => {
+  it('ES6a – rejects invalid type "REGULATION"', () => {
+    expect(() => searchSchema.parse({ query: 'test', resource_type: 'REGULATION' })).toThrow()
+  })
+
+  it('ES6b – rejects invalid type "IMPL"', () => {
+    expect(() => searchSchema.parse({ query: 'test', resource_type: 'IMPL' })).toThrow()
+  })
+
+  it('ES6c – rejects invalid type "directive"', () => {
+    expect(() => searchSchema.parse({ query: 'test', resource_type: 'directive' })).toThrow()
+  })
+})

--- a/tests/guide.test.ts
+++ b/tests/guide.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+// Read the guide source directly to test content
+const guideSource = readFileSync(resolve(__dirname, '../src/prompts/guide.ts'), 'utf-8')
+
+describe('eurlex_guide content', () => {
+  it('ES7a – guide mentions eurlex_search', () => {
+    expect(guideSource).toContain('eurlex_search')
+  })
+
+  it('ES7b – guide mentions eurlex_fetch', () => {
+    expect(guideSource).toContain('eurlex_fetch')
+  })
+
+  it('ES7c – guide mentions eurlex_metadata', () => {
+    expect(guideSource).toContain('eurlex_metadata')
+  })
+
+  it('ES7d – guide mentions eurlex_citations', () => {
+    expect(guideSource).toContain('eurlex_citations')
+  })
+
+  it('ES7e – guide mentions eurlex_by_eurovoc', () => {
+    expect(guideSource).toContain('eurlex_by_eurovoc')
+  })
+
+  it('ES7f – guide mentions eurlex_consolidated', () => {
+    expect(guideSource).toContain('eurlex_consolidated')
+  })
+
+  it('ES8a – guide contains EuroVoc language example for ENG', () => {
+    expect(guideSource).toContain('artificial intelligence')
+  })
+
+  it('ES8b – guide contains EuroVoc language example for DEU', () => {
+    expect(guideSource).toContain('künstliche Intelligenz')
+  })
+
+  it('ES9 – guide contains extended resource types', () => {
+    expect(guideSource).toContain('REG_IMPL')
+    expect(guideSource).toContain('REG_DEL')
+    expect(guideSource).toContain('DIR_IMPL')
+    expect(guideSource).toContain('RECO')
+  })
+})

--- a/tests/setup.test.ts
+++ b/tests/setup.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { SPARQL_ENDPOINT, CELLAR_REST_BASE, DEFAULT_LANGUAGE, DEFAULT_LIMIT, MAX_CHARS_DEFAULT, MAX_CHARS_LIMIT } from '../src/constants.js'
+import { SPARQL_ENDPOINT, CELLAR_REST_BASE, DEFAULT_LANGUAGE, DEFAULT_LIMIT, MAX_CHARS_DEFAULT, MAX_CHARS_LIMIT, RESOURCE_TYPES } from '../src/constants.js'
 
 describe('Project Setup', () => {
   it('constants are defined correctly', () => {
@@ -9,5 +9,8 @@ describe('Project Setup', () => {
     expect(DEFAULT_LIMIT).toBe(10)
     expect(MAX_CHARS_DEFAULT).toBe(20000)
     expect(MAX_CHARS_LIMIT).toBe(50000)
+    expect(RESOURCE_TYPES).toHaveLength(14)
+    expect(RESOURCE_TYPES).toContain('REG')
+    expect(RESOURCE_TYPES).toContain('any')
   })
 })


### PR DESCRIPTION
## Summary
- Expand `resource_type` enum from 5 to 14 values (adds `REG_IMPL`, `REG_DEL`, `DIR_IMPL`, `DIR_DEL`, `DEC_IMPL`, `DEC_DEL`, `ORDER`, `OPIN_AG`, `RECO`)
- Extract `RESOURCE_TYPES` as shared constant in `constants.ts` — single source of truth for `searchSchema` and `eurovocSchema`
- Update `eurlex_guide` prompt to document all 6 tools, extended types, EuroVoc language examples, and search strategies

## Test plan
- [x] 8 new schema tests (ES1-ES6): positive + negative validation for expanded enum
- [x] 9 new guide content tests (ES7-ES9): regression tests for tool names, EuroVoc examples, extended types
- [x] 115/115 tests green, no regressions

Closes #5