### PR TITLE
fix: POSIX-compatible image parsing + CI coverage generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
       - name: Check (typecheck + lint + format + test)
         run: pnpm run check
 
+      - name: Generate coverage report
+        if: matrix.node-version == 22
+        run: pnpm run test:coverage
+
       - name: Upload coverage artifacts
         if: matrix.node-version == 22
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Deploy
         run: |
-          IMAGE=$(grep -oP '":[\\w.-]+"' push-output.txt | tr -d '"')
+          IMAGE=$(sed -n 's/.*"\(:[^"]*\)".*/\1/p' push-output.txt)
           if [ -z "$IMAGE" ]; then
             echo "Failed to parse image name from push output"
             exit 1


### PR DESCRIPTION
## Summary
- Replace `grep -oP` (Perl regex, unavailable on Ubuntu runners) with POSIX `sed` in Lightsail deploy step
- Add `pnpm run test:coverage` step before coverage artifact upload in CI

## Test plan
- [x] Shell test confirmed `grep -oP` fails and `sed` alternative works
- [x] `pnpm run test:coverage` generates coverage/ directory
- [ ] CI passes on this PR