### PR TITLE
fix: reliability, correctness and token-efficiency fixes from July 2026 analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Notes on the response:
 - `authors` lists the resolved agent names (e.g. "European Parliament", "Council of the European Union") instead of an empty array.
 - `legal_basis` lists the CELEX IDs of the acts this document is based on.
 - Date fields (`date_document`, `date_entry_into_force`, `date_end_of_validity`, `date_transposition`) are `null` when absent -- including Cellar's `9999-12-31` sentinel for acts with no defined end of validity, which is normalized to `null`.
-- `directory_codes` are human-readable (`"{code}: {label}"`), not raw URIs.
+- `directory_codes` are human-readable (`"{code-tail}: {label}"`, where `code-tail` is the fragment after the last `/` of the directory-code URI), not raw URIs.
 
 ### eurlex_citations
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ Ask your AI assistant questions like:
 
 - **6 specialized tools** for searching, fetching, and analyzing EU legal documents
 - **EuroVoc thesaurus search** -- find documents by EU taxonomy concepts
-- **Consolidated versions** -- retrieve the latest in-force text of regulations, directives, and decisions
-- **Citation graph** -- explore which documents cite or are cited by a given act
-- **Structured metadata** -- access dates, EuroVoc descriptors, legal basis, and more
+- **Consolidated versions** -- retrieve the latest in-force text of regulations, directives, and decisions, identified by CELEX ID or by doc type + year + number
+- **Citation graph** -- explore which documents cite or are cited by a given act, with a balanced split between the two directions
+- **Structured metadata** -- dates (with `null` instead of Cellar's `9999-12-31` sentinel for open-ended validity), in-force status, authors, legal basis, EuroVoc descriptors, and directory codes
+- **Offset-based pagination** -- `eurlex_fetch` and `eurlex_consolidated` return `next_offset` so long documents can be read in successive calls
 - **Multi-language** -- supports English, German, and French
 - **No API key required** -- uses the public EUR-Lex Cellar SPARQL endpoint
+- **Resilient by default** -- automatic retry with backoff on transient Cellar errors, and in-process caching of EuroVoc labels, consolidated-CELEX lookups, and metadata to cut latency on repeat requests
 
 ## Quick Start
 
@@ -136,11 +138,11 @@ deployment should set `MCP_ALLOWED_HOSTS` to its public hostname(s).
 
 ### eurlex_search
 
-Full-text search across EUR-Lex documents.
+Searches EU legal acts by **title substring** -- a contiguous, case-insensitive phrase match against the document title, not tokenized full-text search. For thematic discovery (the term may not appear in the title) use `eurlex_by_eurovoc` instead. Results are sorted newest-first *within the fetched sample*: for very broad single-word queries this is not guaranteed to be the globally newest match -- narrow with `resource_type` or `date_from`/`date_to` if that matters. The response no longer echoes the internal SPARQL query.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `query` | string | yes | -- | Search term (3-500 chars), e.g. `"artificial intelligence high risk"` |
+| `query` | string | yes | -- | Title substring to match (3-500 chars), e.g. `"artificial intelligence high risk"` |
 | `resource_type` | string | no | `"any"` | Document type filter: `REG`, `DIR`, `DEC`, `JUDG`, `REG_IMPL`, `REG_DEL`, `DIR_IMPL`, `DIR_DEL`, `DEC_IMPL`, `DEC_DEL`, `ORDER`, `OPIN_AG`, `RECO`, `any` |
 | `language` | string | no | `"DEU"` | Language for titles and full text: `DEU`, `ENG`, `FRA` |
 | `limit` | number | no | `10` | Max results (1-50) |
@@ -149,27 +151,34 @@ Full-text search across EUR-Lex documents.
 
 ### eurlex_fetch
 
-Retrieve the full text of a document by its CELEX identifier.
+Retrieve the full text of a document by its CELEX identifier. Long documents are paginated: the response includes `returned_chars`, `total_chars`, and `next_offset` (pass it as the next call's `offset` to keep reading; `next_offset` is `null` once there's nothing left).
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `celex_id` | string | yes | -- | CELEX identifier, e.g. `"32024R1689"` for the AI Act |
 | `language` | string | no | `"DEU"` | Language: `DEU`, `ENG`, `FRA` |
-| `format` | string | no | `"xhtml"` | Output format: `xhtml` (structured) or `plain` (tags stripped) |
-| `max_chars` | number | no | `20000` | Max characters returned (1000-50000) |
+| `format` | string | no | `"xhtml"` | Output format: `xhtml` (structured) or `plain` (tags stripped, whitespace collapsed, entities decoded) |
+| `max_chars` | number | no | `20000` | Max characters returned per call (1000-50000) |
+| `offset` | number | no | `0` | Character offset into the processed document, for pagination |
 
 ### eurlex_metadata
 
-Retrieve structured metadata for a document (dates, EuroVoc descriptors, legal basis, etc.).
+Retrieve structured metadata for a document: document/entry-into-force/end-of-validity dates, in-force status, authors, legal basis, EuroVoc descriptors, and directory codes.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `celex_id` | string | yes | -- | CELEX identifier, e.g. `"32024R1689"` |
 | `language` | string | no | `"DEU"` | Language for titles and EuroVoc labels: `DEU`, `ENG`, `FRA` |
 
+Notes on the response:
+- `authors` lists the resolved agent names (e.g. "European Parliament", "Council of the European Union") instead of an empty array.
+- `legal_basis` lists the CELEX IDs of the acts this document is based on.
+- Date fields (`date_document`, `date_entry_into_force`, `date_end_of_validity`, `date_transposition`) are `null` when absent -- including Cellar's `9999-12-31` sentinel for acts with no defined end of validity, which is normalized to `null`.
+- `directory_codes` are human-readable (`"{code}: {label}"`), not raw URIs.
+
 ### eurlex_citations
 
-Explore the citation graph of a document -- which acts it cites and which acts cite it.
+Explore the citation graph of a document -- which acts it cites, which acts cite it, and amends/based-on/repeals relations.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
@@ -177,6 +186,8 @@ Explore the citation graph of a document -- which acts it cites and which acts c
 | `language` | string | no | `"DEU"` | Language for titles: `DEU`, `ENG`, `FRA` |
 | `direction` | string | no | `"both"` | `cites` (outgoing), `cited_by` (incoming), or `both` |
 | `limit` | number | no | `20` | Max results (1-100) |
+
+With `direction: "both"`, the two directions are queried and split evenly (roughly `limit / 2` each) so that a burst of recent `cited_by` entries can't crowd out `cites` results. The response includes a `counts: { cites, cited_by }` object reporting how many of each were actually found.
 
 ### eurlex_by_eurovoc
 
@@ -191,16 +202,20 @@ Find documents by EuroVoc thesaurus concept (label or URI).
 
 ### eurlex_consolidated
 
-Retrieve the consolidated (in-force) version of a regulation, directive, or decision.
+Retrieve the consolidated (in-force) version of a regulation, directive, or decision. Identify the act with **either** `celex_id` **or** `doc_type` + `year` + `number` -- provide exactly one of the two forms. Like `eurlex_fetch`, the content is paginated via `offset`/`max_chars`/`next_offset`. The response also includes `consolidated_celex` (e.g. `"02016R0679-20160504"`) and `consolidation_date` (`"2016-05-04"`, parsed from that CELEX's date suffix; `null` if the resolved CELEX has none).
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `doc_type` | string | yes | -- | Document type: `reg` (regulation), `dir` (directive), `dec` (decision) |
-| `year` | number | yes | -- | Year of the act (1950-2100), e.g. `2024` |
-| `number` | number | yes | -- | Document number, e.g. `1689` |
+| `celex_id` | string | no* | -- | CELEX ID of the original act, e.g. `"32016R0679"` (GDPR). Alternative to `doc_type`+`year`+`number`; must be a sector-3 CELEX (`3YYYY[R\|L\|D]NNNN`) |
+| `doc_type` | string | no* | -- | Document type: `reg` (regulation), `dir` (directive), `dec` (decision). Alternative to `celex_id`; provide together with `year` and `number` |
+| `year` | number | no* | -- | Year of the act (1950-2100), e.g. `2024`. Required together with `doc_type` and `number` when `celex_id` is not used |
+| `number` | number | no* | -- | Document number, e.g. `1689`. Required together with `doc_type` and `year` when `celex_id` is not used |
 | `language` | string | no | `"DEU"` | Language: `DEU`, `ENG`, `FRA` |
 | `format` | string | no | `"xhtml"` | Output format: `xhtml` or `plain` |
-| `max_chars` | number | no | `20000` | Max characters returned (1000-50000) |
+| `max_chars` | number | no | `20000` | Max characters returned per call (1000-50000) |
+| `offset` | number | no | `0` | Character offset into the processed document, for pagination |
+
+\* Exactly one of `celex_id` or the `doc_type`+`year`+`number` triple must be provided.
 
 ## CELEX Number Schema
 
@@ -258,8 +273,9 @@ pnpm test:integration  # integration tests (hits real API)
 - **Rate limits**: The EUR-Lex Cellar API is public but may throttle excessive requests.
 - **Document availability**: Not all documents have full text in all languages.
 - **Consolidated versions**: Only available for regulations, directives, and decisions.
-- **Response size**: Full text is truncated at `max_chars` (default 20,000 characters) to stay within LLM context limits.
-- **SPARQL timeouts**: Complex EuroVoc queries may occasionally time out on the Cellar endpoint.
+- **Response size**: Full text is returned per call in `max_chars` slices (default 20,000 characters) to stay within LLM context limits -- use `offset`/`next_offset` on `eurlex_fetch`/`eurlex_consolidated` to read the rest.
+- **SPARQL timeouts**: Complex queries may occasionally time out on the Cellar endpoint despite the built-in retry with backoff; narrow broad `eurlex_search`/`eurlex_by_eurovoc` queries with `resource_type` or date filters if this happens.
+- **Search ordering**: `eurlex_search` results are sorted newest-first within the fetched sample only -- for very broad queries this is not guaranteed to be the single globally newest match.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,27 @@ Add to `~/.windsurf/mcp.json`:
 }
 ```
 
+### HTTP Transport (Remote Deployments)
+
+When running the server over HTTP (`pnpm start:http` / `dist/http.js`) instead of stdio, it's exposed
+to any client that can reach it over the network. To protect against DNS rebinding attacks, set these
+environment variables:
+
+| Variable | Required | Description |
+|----------|----------|--------------|
+| `MCP_ALLOWED_HOSTS` | no (but strongly recommended for public deployments) | Comma-separated list of allowed `Host` header values. Must match the header **exactly**, including the port if the server isn't reachable on the default HTTP(S) port. |
+| `MCP_ALLOWED_ORIGINS` | no | Comma-separated list of allowed `Origin` header values. Only enforced when `MCP_ALLOWED_ORIGINS` is set together with `MCP_ALLOWED_HOSTS`. |
+
+Production example:
+
+```bash
+MCP_ALLOWED_HOSTS=mcp.honeyfield.at
+```
+
+**This protection is opt-in.** If `MCP_ALLOWED_HOSTS` is not set, the server starts as before and logs
+a one-line startup warning (`MCP_ALLOWED_HOSTS not set — DNS rebinding protection disabled`). Any public
+deployment should set `MCP_ALLOWED_HOSTS` to its public hostname(s).
+
 ## Tool Reference
 
 ### eurlex_search

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ environment variables:
 | `MCP_ALLOWED_HOSTS` | no (but strongly recommended for public deployments) | Comma-separated list of allowed `Host` header values. Must match the header **exactly**, including the port if the server isn't reachable on the default HTTP(S) port. |
 | `MCP_ALLOWED_ORIGINS` | no | Comma-separated list of allowed `Origin` header values. Only enforced when `MCP_ALLOWED_ORIGINS` is set together with `MCP_ALLOWED_HOSTS`. |
 
+**Important:** If your server runs behind a reverse proxy or load balancer, ensure it forwards the original `Host` header unmodified (e.g. nginx `proxy_set_header Host $host;`), otherwise `MCP_ALLOWED_HOSTS` validation will reject all legitimate traffic — the SDK compares the raw Host header as an exact string.
+
 Production example:
 
 ```bash

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,8 +10,10 @@ export const SESSION_TTL_MS = 30 * 60 * 1000;
 
 // Retry policy for Cellar SPARQL/REST calls: retry on network errors, timeouts,
 // and HTTP 5xx — never on 4xx. Max 2 retries with 500ms then 1500ms delay.
-export const MAX_RETRIES = 2;
-export const RETRY_DELAYS_MS = [500, 1500];
+// MAX_RETRIES is derived from RETRY_DELAYS_MS.length so the two can never drift
+// apart (e.g. in an error message reporting the retry count).
+export const RETRY_DELAYS_MS = [500, 1500] as const;
+export const MAX_RETRIES = RETRY_DELAYS_MS.length;
 
 // {4,30} — supports parenthesized corrigenda suffixes, e.g. 32023D2454(02)
 export const CELEX_REGEX = /^\d[A-Z0-9()]{4,30}$/;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,17 @@ export const RETRY_DELAYS_MS = [500, 1500];
 // {4,30} — supports parenthesized corrigenda suffixes, e.g. 32023D2454(02)
 export const CELEX_REGEX = /^\d[A-Z0-9()]{4,30}$/;
 
+// In-memory TTL caches on CellarClient (Task 6). Expiry is checked on read
+// only — no background timers. Errors are never cached; legitimate "not
+// found" (null) results ARE cached, since re-querying Cellar for the same
+// non-existent lookup within the TTL window would be wasted work.
+export const EUROVOC_LABEL_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+export const EUROVOC_LABEL_CACHE_MAX_ENTRIES = 500;
+export const CONSOLIDATED_CELEX_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+export const CONSOLIDATED_CELEX_CACHE_MAX_ENTRIES = 500;
+export const METADATA_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+export const METADATA_CACHE_MAX_ENTRIES = 200;
+
 export const RESOURCE_TYPES = [
   'REG',
   'REG_IMPL',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,11 @@ export const MAX_CHARS_LIMIT = 50000;
 export const REQUEST_TIMEOUT_MS = 30000;
 export const SESSION_TTL_MS = 30 * 60 * 1000;
 
+// Retry policy for Cellar SPARQL/REST calls: retry on network errors, timeouts,
+// and HTTP 5xx — never on 4xx. Max 2 retries with 500ms then 1500ms delay.
+export const MAX_RETRIES = 2;
+export const RETRY_DELAYS_MS = [500, 1500];
+
 // {4,30} — supports parenthesized corrigenda suffixes, e.g. 32023D2454(02)
 export const CELEX_REGEX = /^\d[A-Z0-9()]{4,30}$/;
 

--- a/src/http.ts
+++ b/src/http.ts
@@ -103,6 +103,8 @@ export function createApp(): {
         transports.set(sid, transport);
         lastSeen.set(sid, Date.now());
       },
+      // Note: enableDnsRebindingProtection, allowedHosts, and allowedOrigins are marked deprecated
+      // upstream in favor of external middleware, but used deliberately here (no-new-dependencies constraint).
       ...(dnsRebindingProtectionEnabled && {
         enableDnsRebindingProtection: true,
         allowedHosts,

--- a/src/http.ts
+++ b/src/http.ts
@@ -8,6 +8,19 @@ import rateLimit from 'express-rate-limit';
 import { SESSION_TTL_MS } from './constants.js';
 import { createServer } from './server.js';
 
+/**
+ * Parses a comma-separated env var into a trimmed, non-empty list of entries.
+ * Returns undefined when the env var is unset or contains no usable entries.
+ */
+function parseHostList(value: string | undefined): string[] | undefined {
+  if (!value) return undefined;
+  const entries = value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  return entries.length > 0 ? entries : undefined;
+}
+
 // Rate limiting: each MCP request triggers upstream EUR-Lex API calls
 export const mcpLimiter = rateLimit({
   windowMs: 60_000,
@@ -27,6 +40,17 @@ export function createApp(): {
   const app = express();
   app.use(express.json());
   app.use('/mcp', mcpLimiter);
+
+  // DNS rebinding protection is strictly opt-in via MCP_ALLOWED_HOSTS: this server
+  // is deployed publicly (mcp.honeyfield.at) with no auth, and defaulting protection
+  // on would break existing deployments whose env doesn't set it yet.
+  const allowedHosts = parseHostList(process.env.MCP_ALLOWED_HOSTS);
+  const allowedOrigins = parseHostList(process.env.MCP_ALLOWED_ORIGINS);
+  const dnsRebindingProtectionEnabled = allowedHosts !== undefined;
+
+  if (!dnsRebindingProtectionEnabled) {
+    console.warn('MCP_ALLOWED_HOSTS not set — DNS rebinding protection disabled');
+  }
 
   const transports = new Map<string, StreamableHTTPServerTransport>();
   const lastSeen = new Map<string, number>();
@@ -79,6 +103,11 @@ export function createApp(): {
         transports.set(sid, transport);
         lastSeen.set(sid, Date.now());
       },
+      ...(dnsRebindingProtectionEnabled && {
+        enableDnsRebindingProtection: true,
+        allowedHosts,
+        ...(allowedOrigins && { allowedOrigins }),
+      }),
     });
 
     transport.onclose = (): void => {

--- a/src/prompts/guide.ts
+++ b/src/prompts/guide.ts
@@ -1,77 +1,75 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
-const GUIDE_TEXT = `# EUR-Lex Recherche-Guide
+const GUIDE_TEXT = `# EUR-Lex Research Guide
 
-## Verfügbare Tools
+## Available tools
 
-### eurlex_search — Titelsuche
-Sucht EU-Rechtsakte nach Titel. Unterstützt Filter nach Typ, Datum, Sprache.
+### eurlex_search — Title search
+Searches EU legal acts by title substring (contiguous phrase, case-insensitive — not tokenized full-text search). Supports filtering by resource_type, date_from/date_to, and language. Broad single-word queries over common terms can be slow against the Cellar SPARQL endpoint; narrow with resource_type or a date range if a search times out. Results are newest-first within the fetched sample, not necessarily the globally newest match for very broad queries.
 
-### eurlex_fetch — Volltext abrufen
-Ruft den Volltext eines Rechtsakts per CELEX-ID ab.
+### eurlex_fetch — Full text
+Fetches the full text of a legal act by CELEX ID. Paginate long documents with offset and max_chars — pass the previous response's next_offset to continue reading until it is null.
 
-### eurlex_metadata — Metadaten abfragen
-Liefert Inkrafttreten, Gültigkeit, In-Kraft-Status, Autoren, EuroVoc-Themen, Directory-Codes.
+### eurlex_metadata — Metadata lookup
+Returns dates (document, entry into force, end of validity), in-force status, authors, legal basis (CELEX IDs of the acts it is based on), EuroVoc descriptors, and directory codes.
 
-### eurlex_citations — Zitierungen & Beziehungen
-Findet Zitierungen, Rechtsgrundlagen, Änderungen zu einem Rechtsakt.
-Richtungen: cites (zitiert von), cited_by (zitiert durch), both.
+### eurlex_citations — Citations & relationships
+Finds citations, legal basis, and amendments for a legal act. Directions: cites (referenced by this act), cited_by (acts referencing this one), both (a balanced split of both directions, with a counts field reporting how many of each side were found).
 
-### eurlex_by_eurovoc — Thematische Suche
-Sucht Rechtsakte nach EuroVoc-Konzept. Findet auch Dokumente, die das Stichwort nicht im Titel haben.
-Akzeptiert Labels ("artificial intelligence") oder URIs ("http://eurovoc.europa.eu/4424").
+### eurlex_by_eurovoc — Thematic search
+Searches legal acts by EuroVoc concept. Finds documents that don't have the search term in their title — the right tool for "documents about X". Accepts a label ("artificial intelligence") or a URI ("http://eurovoc.europa.eu/4424").
 
-### eurlex_consolidated — Konsolidierte Fassung
-Ruft die aktuell gültige Fassung ab (mit allen Änderungen eingearbeitet) via ELI.
+### eurlex_consolidated — Consolidated version
+Fetches the currently in-force version (with all amendments merged in) via ELI. Identify the act with celex_id (e.g. "32016R0679") OR with doc_type + year + number — provide exactly one of the two. celex_id must be a sector-3 secondary-law CELEX (3YYYY[R|L|D]NNNN). Paginate with offset and max_chars like eurlex_fetch.
 
-## CELEX-Nummern-Schema
-- 3 = Sekundärrecht EU (Verordnungen, Richtlinien, Entscheidungen)
-- Danach: Jahr (4-stellig) + Typ-Buchstabe + Dokumentnummer
-- Beispiele: 32024R1689 (AI Act), 32016R0679 (DSGVO), 32022L2555 (NIS2)
+## CELEX numbering scheme
+- 3 = EU secondary legislation (regulations, directives, decisions)
+- Then: year (4 digits) + type letter + document number
+- Examples: 32024R1689 (AI Act), 32016R0679 (GDPR), 32022L2555 (NIS2)
 
-## Typ-Buchstaben → resource_type Mapping
-| CELEX-Buchstabe | resource_type | Bedeutung |
+## Type letter → resource_type mapping
+| CELEX letter | resource_type | Meaning |
 |---|---|---|
-| R | REG | Verordnung (direkt anwendbar) |
-| L | DIR | Richtlinie (muss umgesetzt werden) |
-| D | DEC | Entscheidung/Beschluss |
+| R | REG | Regulation (directly applicable) |
+| L | DIR | Directive (must be transposed) |
+| D | DEC | Decision |
 
-## Erweiterte Typen
-REG_IMPL (Durchführungsverordnung), REG_DEL (Delegierte Verordnung),
-DIR_IMPL (Durchführungsrichtlinie), DIR_DEL (Delegierte Richtlinie),
-DEC_IMPL (Durchführungsbeschluss), DEC_DEL (Delegierter Beschluss),
-RECO (Empfehlung),
-JUDG (Urteil), ORDER (Beschluss), OPIN_AG (Schlussanträge GA)
+## Extended types
+REG_IMPL (implementing regulation), REG_DEL (delegated regulation),
+DIR_IMPL (implementing directive), DIR_DEL (delegated directive),
+DEC_IMPL (implementing decision), DEC_DEL (delegated decision),
+RECO (recommendation),
+JUDG (judgment), ORDER (court order), OPIN_AG (Advocate General opinion)
 
-## Suchstrategie
-1. eurlex_search sucht NUR in Titeln → für thematische Suche eurlex_by_eurovoc verwenden
-2. Suchbegriffe in der Sprache des Titels verwenden
-3. Bei Nicht-Treffern: Synonyme probieren ("KI" vs "künstliche Intelligenz")
-4. Bekannte CELEX-ID? → Direkt eurlex_fetch oder eurlex_metadata nutzen
-5. Rechtsbeziehungen? → eurlex_citations für Zitierungsketten
-6. Konsolidierte Fassung? → eurlex_consolidated für geltendes Recht
+## Search strategy
+1. eurlex_search only matches titles → use eurlex_by_eurovoc for thematic discovery
+2. Use search terms in the language of the title
+3. No hits? Try synonyms (e.g. "AI" vs "artificial intelligence")
+4. Known CELEX ID? → Use eurlex_fetch or eurlex_metadata directly
+5. Legal relationships? → eurlex_citations for citation chains
+6. Consolidated version? → eurlex_consolidated for the currently in-force text
 
-## EuroVoc-Sprachbeispiele
-- Bei language=ENG: "artificial intelligence", "data protection", "cybersecurity"
-- Bei language=DEU: "künstliche Intelligenz", "Datenschutz", "Cybersicherheit"
-- Bei language=FRA: "intelligence artificielle", "protection des données"
-EuroVoc-Labels sind sprachabhängig — passende Sprache zum language-Parameter wählen!
+## EuroVoc language examples
+- language=ENG: "artificial intelligence", "data protection", "cybersecurity"
+- language=DEU: "künstliche Intelligenz", "Datenschutz", "Cybersicherheit"
+- language=FRA: "intelligence artificielle", "protection des données"
+EuroVoc labels are language-specific — match the language to the language parameter!
 
-## Bekannte CELEX-IDs wichtiger Rechtsakte
+## Well-known CELEX IDs
 - AI Act: 32024R1689
-- DSGVO: 32016R0679
-- NIS2-Richtlinie: 32022L2555
+- GDPR: 32016R0679
+- NIS2 Directive: 32022L2555
 - Digital Services Act: 32022R2065
 - Digital Markets Act: 32022R1925
 - Data Act: 32023R2854
 - Data Governance Act: 32022R0868
 
 ## Limitations
-- Sehr lange Dokumente werden bei max_chars abgeschnitten
-- SPARQL-Antwortzeit: 2-10 Sekunden
-- Nicht alle Dokumente haben eine XHTML-Version
-- EuroVoc-Labels sind sprachabhängig — englische Begriffe bei language=ENG
-- Konsolidierte Fassungen existieren nicht für alle Rechtsakte`;
+- Very long documents are paginated via offset/max_chars — check next_offset to continue reading
+- SPARQL response time: typically 2-10 seconds; broad title searches can be slower and may time out
+- Not every document has an XHTML version
+- EuroVoc labels are language-specific — use terms matching the language parameter
+- Not every legal act has a consolidated version`;
 
 export function registerGuidePrompt(server: McpServer): void {
   server.prompt('eurlex_guide', {}, () => ({

--- a/src/schemas/citationsSchema.ts
+++ b/src/schemas/citationsSchema.ts
@@ -4,15 +4,15 @@ import { CELEX_REGEX } from '../constants.js';
 
 export const citationsSchema = z
   .object({
-    celex_id: z.string().regex(CELEX_REGEX).describe("CELEX-Identifier, z.B. '32024R1689'"),
-    language: z.enum(['DEU', 'ENG', 'FRA']).default('DEU').describe('Sprache für Titel'),
+    celex_id: z.string().regex(CELEX_REGEX).describe("CELEX identifier, e.g. '32024R1689'"),
+    language: z.enum(['DEU', 'ENG', 'FRA']).default('DEU').describe('Language of the title'),
     direction: z
       .enum(['cites', 'cited_by', 'both'])
       .default('both')
       .describe(
-        'Richtung: cites=zitiert von diesem Dokument, cited_by=zitiert dieses Dokument, both=beides',
+        'Direction: cites=acts referenced by this document, cited_by=acts referencing this document, both=a balanced split of both directions',
       ),
-    limit: z.number().int().min(1).max(100).default(20).describe('Max. Ergebnisse'),
+    limit: z.number().int().min(1).max(100).default(20).describe('Maximum number of results'),
   })
   .strict();
 

--- a/src/schemas/consolidatedSchema.ts
+++ b/src/schemas/consolidatedSchema.ts
@@ -1,21 +1,54 @@
 import { z } from 'zod';
 
+import { CELEX_REGEX } from '../constants.js';
+
 export const consolidatedSchema = z
   .object({
+    celex_id: z
+      .string()
+      .regex(CELEX_REGEX)
+      .optional()
+      .describe(
+        'CELEX ID of the original act, e.g. "32016R0679" (GDPR). Alternative to doc_type + year + number — provide exactly one of the two input forms. Must be a sector-3 secondary-law CELEX (pattern 3YYYY[R|L|D]NNNN).',
+      ),
     doc_type: z
       .enum(['reg', 'dir', 'dec'])
-      .describe('Dokumenttyp: reg=Verordnung, dir=Richtlinie, dec=Entscheidung'),
-    year: z.number().int().min(1950).max(2100).describe('Jahr des Rechtsakts, z.B. 2024'),
-    number: z.number().int().min(1).describe('Dokumentnummer, z.B. 1689'),
-    language: z.enum(['DEU', 'ENG', 'FRA']).default('DEU').describe('Sprache'),
-    format: z.enum(['xhtml', 'plain']).default('xhtml').describe('Ausgabeformat'),
+      .optional()
+      .describe(
+        'Document type: reg=regulation, dir=directive, dec=decision. Alternative to celex_id — provide together with year and number.',
+      ),
+    year: z
+      .number()
+      .int()
+      .min(1950)
+      .max(2100)
+      .optional()
+      .describe(
+        'Year of the act, e.g. 2024. Required together with doc_type and number when celex_id is not used.',
+      ),
+    number: z
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe(
+        'Document number, e.g. 1689. Required together with doc_type and year when celex_id is not used.',
+      ),
+    language: z
+      .enum(['DEU', 'ENG', 'FRA'])
+      .default('DEU')
+      .describe('Language of the returned text'),
+    format: z
+      .enum(['xhtml', 'plain'])
+      .default('xhtml')
+      .describe('Output format: xhtml=structured XHTML, plain=text with XHTML tags stripped'),
     max_chars: z
       .number()
       .int()
       .min(1000)
       .max(50000)
       .default(20000)
-      .describe('Maximale Zeichenanzahl'),
+      .describe('Maximum number of characters returned'),
     offset: z
       .number()
       .int()
@@ -26,3 +59,43 @@ export const consolidatedSchema = z
   .strict();
 
 export type ConsolidatedInput = z.infer<typeof consolidatedSchema>;
+
+/**
+ * Enforces "exactly one of celex_id / (doc_type + year + number)". This is an
+ * object-level invariant that `server.tool(consolidatedSchema.shape)` cannot
+ * express: the SDK only registers the per-field shape and strips refinements
+ * on the object as a whole. The handler (tools/consolidated.ts) re-validates
+ * input against this refined schema — via an explicit `.parse()` call it
+ * documents the reason for — to actually enforce the invariant.
+ */
+export const consolidatedInputSchema = consolidatedSchema.superRefine((data, ctx) => {
+  const hasCelex = data.celex_id !== undefined;
+  const tripleFields = [data.doc_type, data.year, data.number];
+  const hasAnyTripleField = tripleFields.some((field) => field !== undefined);
+  const hasFullTriple = tripleFields.every((field) => field !== undefined);
+
+  if (hasCelex && hasAnyTripleField) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        'Provide either celex_id or doc_type + year + number, not both. Pick one input form.',
+    });
+    return;
+  }
+
+  if (!hasCelex && !hasAnyTripleField) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Provide either celex_id or doc_type + year + number to identify the act.',
+    });
+    return;
+  }
+
+  // Remaining cases: celex-only (valid) or triple-only, full or partial.
+  if (hasAnyTripleField && !hasFullTriple) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'doc_type, year, and number must all be provided together.',
+    });
+  }
+});

--- a/src/schemas/consolidatedSchema.ts
+++ b/src/schemas/consolidatedSchema.ts
@@ -16,6 +16,12 @@ export const consolidatedSchema = z
       .max(50000)
       .default(20000)
       .describe('Maximale Zeichenanzahl'),
+    offset: z
+      .number()
+      .int()
+      .min(0)
+      .default(0)
+      .describe('Character offset for pagination (0-based)'),
   })
   .strict();
 

--- a/src/schemas/eurovocSchema.ts
+++ b/src/schemas/eurovocSchema.ts
@@ -9,14 +9,14 @@ export const eurovocSchema = z
       .min(2)
       .max(500)
       .describe(
-        "EuroVoc-Konzept: Label (z.B. 'artificial intelligence') oder URI (z.B. 'http://eurovoc.europa.eu/4424')",
+        "EuroVoc concept: a label (e.g. 'artificial intelligence') or a URI (e.g. 'http://eurovoc.europa.eu/4424')",
       ),
-    resource_type: z.enum(RESOURCE_TYPES).default('any').describe('Dokumenttyp-Filter'),
+    resource_type: z.enum(RESOURCE_TYPES).default('any').describe('Document type filter'),
     language: z
       .enum(['DEU', 'ENG', 'FRA'])
       .default('DEU')
-      .describe('Sprache für Titel und EuroVoc-Labels'),
-    limit: z.number().int().min(1).max(50).default(10).describe('Max. Ergebnisse'),
+      .describe('Language of the title and EuroVoc labels'),
+    limit: z.number().int().min(1).max(50).default(10).describe('Maximum number of results'),
   })
   .strict();
 

--- a/src/schemas/fetchSchema.ts
+++ b/src/schemas/fetchSchema.ts
@@ -20,6 +20,12 @@ export const fetchSchema = z
       .max(50000)
       .default(20000)
       .describe('Maximale Zeichenanzahl des zurückgegebenen Texts'),
+    offset: z
+      .number()
+      .int()
+      .min(0)
+      .default(0)
+      .describe('Character offset for pagination (0-based)'),
   })
   .strict();
 

--- a/src/schemas/fetchSchema.ts
+++ b/src/schemas/fetchSchema.ts
@@ -7,19 +7,19 @@ export const fetchSchema = z
     celex_id: z
       .string()
       .regex(CELEX_REGEX)
-      .describe("CELEX-Identifier, z.B. '32024R1689' für den AI Act"),
-    language: z.enum(['DEU', 'ENG', 'FRA']).default('DEU').describe('Sprache des Volltexts'),
+      .describe("CELEX identifier, e.g. '32024R1689' for the AI Act"),
+    language: z.enum(['DEU', 'ENG', 'FRA']).default('DEU').describe('Language of the full text'),
     format: z
       .enum(['xhtml', 'plain'])
       .default('xhtml')
-      .describe('Ausgabeformat: xhtml=strukturiertes XHTML, plain=Text (XHTML-Tags entfernt)'),
+      .describe('Output format: xhtml=structured XHTML, plain=text with XHTML tags stripped'),
     max_chars: z
       .number()
       .int()
       .min(1000)
       .max(50000)
       .default(20000)
-      .describe('Maximale Zeichenanzahl des zurückgegebenen Texts'),
+      .describe('Maximum number of characters returned'),
     offset: z
       .number()
       .int()

--- a/src/schemas/metadataSchema.ts
+++ b/src/schemas/metadataSchema.ts
@@ -7,11 +7,11 @@ export const metadataSchema = z
     celex_id: z
       .string()
       .regex(CELEX_REGEX)
-      .describe("CELEX-Identifier, z.B. '32024R1689' für den AI Act"),
+      .describe("CELEX identifier, e.g. '32024R1689' for the AI Act"),
     language: z
       .enum(['DEU', 'ENG', 'FRA'])
       .default('DEU')
-      .describe('Sprache für Titel und EuroVoc-Labels'),
+      .describe('Language of the title and EuroVoc labels'),
   })
   .strict();
 

--- a/src/schemas/searchSchema.ts
+++ b/src/schemas/searchSchema.ts
@@ -8,28 +8,30 @@ export const searchSchema = z
       .string()
       .min(3)
       .max(500)
-      .describe("Suchbegriff, z.B. 'artificial intelligence high risk'"),
+      .describe(
+        'Title substring to search for, e.g. "artificial intelligence high risk". Matched as a contiguous phrase, case-insensitive.',
+      ),
     resource_type: z
       .enum(RESOURCE_TYPES)
       .default('any')
       .describe(
-        'Dokumenttyp: REG=Verordnung, DIR=Richtlinie, DEC=Entscheidung, JUDG=Urteil, REG_IMPL=Durchführungsverordnung, REG_DEL=Delegierte Verordnung, RECO=Empfehlung, ORDER=Gerichtsbeschluss, OPIN_AG=Schlussanträge des Generalanwalts',
+        'Document type filter: REG=regulation, DIR=directive, DEC=decision, JUDG=judgment, REG_IMPL=implementing regulation, REG_DEL=delegated regulation, RECO=recommendation, ORDER=court order, OPIN_AG=Advocate General opinion',
       ),
     language: z
       .enum(['DEU', 'ENG', 'FRA'])
       .default('DEU')
-      .describe('Sprache für Titel und Volltext'),
-    limit: z.number().int().min(1).max(50).default(10).describe('Max. Ergebnisse'),
+      .describe('Language of the title and full text'),
+    limit: z.number().int().min(1).max(50).default(10).describe('Maximum number of results'),
     date_from: z
       .string()
       .regex(/^\d{4}-\d{2}-\d{2}$/)
       .optional()
-      .describe('Filter ab Datum, Format: YYYY-MM-DD'),
+      .describe('Filter from this date onward, format YYYY-MM-DD'),
     date_to: z
       .string()
       .regex(/^\d{4}-\d{2}-\d{2}$/)
       .optional()
-      .describe('Filter bis Datum, Format: YYYY-MM-DD'),
+      .describe('Filter up to this date, format YYYY-MM-DD'),
   })
   .strict();
 

--- a/src/services/cellarClient.ts
+++ b/src/services/cellarClient.ts
@@ -42,6 +42,18 @@ export const VALID_RELATIONSHIPS = new Set<CitationEntry['relationship']>([
   'repealed_by',
 ]);
 
+/**
+ * Relationships that belong to the "cites" side (this act references others).
+ * Their inverses (cited_by/basis_for/amended_by/repealed_by) form the "cited_by"
+ * side. Used to compute CitationsResult.counts regardless of query direction.
+ */
+const CITES_SIDE_RELATIONSHIPS = new Set<CitationEntry['relationship']>([
+  'cites',
+  'based_on',
+  'amends',
+  'repeals',
+]);
+
 /** Shape of a single SPARQL binding value */
 interface SparqlBindingValue {
   type: string;
@@ -216,18 +228,24 @@ export class CellarClient {
 
     const whereLines: string[] = [];
 
-    // Resource type filter
+    // Resource type binding. When a specific type is requested we keep the filter
+    // triple and BIND that exact type as ?resType — a work can carry several
+    // resource-types, and re-deriving ?resType from a generic ?resTypeUri could
+    // report a *different* type than the one filtered on. Only for 'any' do we
+    // extract the type from the (single) ?resTypeUri binding.
+    // params.resource_type is Zod-validated against RESOURCE_TYPES, so it is safe
+    // to embed without escaping.
     if (params.resource_type !== 'any') {
       whereLines.push(
         `    ?work cdm:work_has_resource-type <http://publications.europa.eu/resource/authority/resource-type/${params.resource_type}> .`,
+        `    BIND("${params.resource_type}" AS ?resType)`,
+      );
+    } else {
+      whereLines.push(
+        '    ?work cdm:work_has_resource-type ?resTypeUri .',
+        '    BIND(REPLACE(STR(?resTypeUri), "^.*/", "") AS ?resType)',
       );
     }
-
-    // Always bind the resource type
-    whereLines.push(
-      '    ?work cdm:work_has_resource-type ?resTypeUri .',
-      '    BIND(REPLACE(STR(?resTypeUri), "^.*/", "") AS ?resType)',
-    );
 
     // CELEX identifier
     whereLines.push('    ?work cdm:resource_legal_id_celex ?celex .');
@@ -253,6 +271,14 @@ export class CellarClient {
       whereLines.push(`    FILTER(?date <= "${params.date_to}"^^xsd:date)`);
     }
 
+    // No ORDER BY: `ORDER BY DESC(?date)` forces Virtuoso to materialize ALL
+    // matching expressions before applying LIMIT — live-verified to time out for
+    // broad title terms ("data protection", "Datenschutz"). Instead we oversample
+    // (so Virtuoso can stream-abort early) and sort/dedup/slice client-side in
+    // sparqlQuery(). Trade-off: results are "newest-first within the fetched
+    // sample", not globally newest.
+    const oversampledLimit = Math.min(params.limit * 3, 150);
+
     const query = [
       'PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>',
       'PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>',
@@ -260,8 +286,7 @@ export class CellarClient {
       'SELECT DISTINCT ?work ?celex ?title ?date ?resType WHERE {',
       ...whereLines,
       '}',
-      `ORDER BY DESC(?date)`,
-      `LIMIT ${params.limit}`,
+      `LIMIT ${oversampledLimit}`,
     ].join('\n');
 
     return query;
@@ -300,15 +325,30 @@ export class CellarClient {
       };
     });
 
-    // Deduplicate by CELEX ID (same document can have multiple resource types)
+    // The SPARQL query has no ORDER BY (see buildSparqlQuery) and oversamples the
+    // LIMIT, so we sort here: date descending, with empty/missing dates last.
+    // ISO date strings sort lexicographically = chronologically. Array.sort is
+    // stable, so equal-date rows keep their original order.
+    const sorted = [...results].sort((a, b) => {
+      if (a.date === b.date) return 0;
+      if (a.date === '') return 1;
+      if (b.date === '') return -1;
+      return a.date < b.date ? 1 : -1;
+    });
+
+    // Deduplicate by CELEX ID (same document can have multiple resource types).
+    // After the date-desc sort, the first occurrence per CELEX is the newest.
     const seen = new Set<string>();
-    const deduped = results.filter((r) => {
+    const deduped = sorted.filter((r) => {
       if (seen.has(r.celex)) return false;
       seen.add(r.celex);
       return true;
     });
 
-    return { results: deduped, sparql };
+    // Slice back down to the caller's requested limit (we oversampled for the sort).
+    const limited = deduped.slice(0, fullParams.limit);
+
+    return { results: limited, sparql };
   }
 
   /**
@@ -533,20 +573,19 @@ export class CellarClient {
   }
 
   /**
-   * Fetches citations/relationships for a CELEX ID from the SPARQL endpoint.
+   * Runs one directional citations query and parses its bindings into entries.
    */
-  async citationsQuery(
+  private async fetchCitationEntries(
     celexId: string,
     language: string,
-    direction: 'cites' | 'cited_by' | 'both',
+    direction: 'cites' | 'cited_by',
     limit: number,
-  ): Promise<CitationsResult> {
-    const sparql = this.buildCitationsQuery(celexId, language, direction, limit);
+  ): Promise<CitationEntry[]> {
     const httpLang = LANGUAGE_HTTP_MAP[language] ?? 'de';
-
+    const sparql = this.buildCitationsQuery(celexId, language, direction, limit);
     const data = await this.executeSparql<CitationsSparqlResponse>(sparql);
 
-    const citations = data.results.bindings.map((b) => {
+    return data.results.bindings.map((b) => {
       const rel = b.rel.value;
       if (!VALID_RELATIONSHIPS.has(rel as CitationEntry['relationship'])) {
         throw new Error(`Unexpected relationship value from SPARQL: ${rel}`);
@@ -560,27 +599,68 @@ export class CellarClient {
         eurlex_url: `${EURLEX_BASE}/${httpLang}/TXT/?uri=CELEX:${b.celex.value}`,
       };
     });
+  }
+
+  /**
+   * Fetches citations/relationships for a CELEX ID from the SPARQL endpoint.
+   *
+   * For `both`, the two directions are queried separately (each with roughly half
+   * the limit) and run in parallel. A single combined UNION query ordered by date
+   * lets recent `cited_by` rows crowd out the `cites` side entirely — live-verified.
+   * Splitting guarantees a balanced result. `cites`-side entries are listed first.
+   */
+  async citationsQuery(
+    celexId: string,
+    language: string,
+    direction: 'cites' | 'cited_by' | 'both',
+    limit: number,
+  ): Promise<CitationsResult> {
+    let citations: CitationEntry[];
+
+    if (direction === 'both') {
+      const [citesEntries, citedByEntries] = await Promise.all([
+        this.fetchCitationEntries(celexId, language, 'cites', Math.ceil(limit / 2)),
+        this.fetchCitationEntries(celexId, language, 'cited_by', Math.floor(limit / 2)),
+      ]);
+      // cites-side first, then cited_by-side
+      citations = [...citesEntries, ...citedByEntries];
+    } else {
+      citations = await this.fetchCitationEntries(celexId, language, direction, limit);
+    }
+
+    // counts classify by relationship, so they stay correct for every direction.
+    const cites = citations.filter((c) => CITES_SIDE_RELATIONSHIPS.has(c.relationship)).length;
 
     return {
       celex_id: celexId,
       citations,
       total: citations.length,
+      counts: { cites, cited_by: citations.length - cites },
     };
   }
 
   /**
    * Resolves a EuroVoc label to its concept URI via a lightweight SPARQL query.
    * Returns null if no matching concept is found.
+   *
+   * Precision: labels are filtered to the request language, and results are ordered
+   * so an exact (case-insensitive) label match wins over a mere substring match, then
+   * the shortest label — a deterministic single winner instead of an arbitrary one.
    */
-  async resolveEurovocLabel(label: string): Promise<string | null> {
+  async resolveEurovocLabel(label: string, language: string): Promise<string | null> {
+    const escaped = escapeSparqlString(label);
+    const langLower = LANGUAGE_HTTP_MAP[language] ?? 'de';
+
     const sparql = [
       'PREFIX skos: <http://www.w3.org/2004/02/skos/core#>',
       'SELECT ?concept WHERE {',
       '  ?concept a skos:Concept .',
       '  ?concept skos:prefLabel ?label .',
       `  FILTER(STRSTARTS(STR(?concept), "http://eurovoc.europa.eu/"))`,
-      `  FILTER(CONTAINS(LCASE(STR(?label)), LCASE("${escapeSparqlString(label)}")))`,
+      `  FILTER(LANG(?label) = "${langLower}")`,
+      `  FILTER(CONTAINS(LCASE(STR(?label)), LCASE("${escaped}")))`,
       '}',
+      `ORDER BY DESC(LCASE(STR(?label)) = LCASE("${escaped}")) STRLEN(STR(?label))`,
       'LIMIT 1',
     ].join('\n');
 
@@ -668,7 +748,7 @@ export class CellarClient {
     if (isUri) {
       conceptUri = concept;
     } else {
-      const resolved = await this.resolveEurovocLabel(concept);
+      const resolved = await this.resolveEurovocLabel(concept, language);
       if (resolved === null) {
         return [];
       }
@@ -705,14 +785,23 @@ export class CellarClient {
     number: number,
   ): Promise<string | null> {
     const typeLetter = CellarClient.DOC_TYPE_CELEX_MAP[docType] ?? 'R';
-    const celexPrefix = `0${year}${typeLetter}${String(number).padStart(4, '0')}`;
+    const celexBody = `0${year}${typeLetter}${String(number).padStart(4, '0')}`;
+
+    // Anchored regex instead of a bare STRSTARTS prefix: a 4-digit number like
+    // 0679 must NOT match a longer document number (e.g. 06791). The consolidated
+    // CELEX is either the bare body or the body plus a "-YYYYMMDD" consolidation
+    // date suffix. year/typeLetter/number are Zod-validated numbers/enums (not
+    // user-controlled free text), so no escaping is required.
+    const celexRegex = `^${celexBody}(-[0-9]{8})?$`;
 
     const sparql = [
       'PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>',
       `SELECT ?celex WHERE {`,
       `  ?work cdm:resource_legal_id_celex ?celex .`,
-      `  FILTER(STRSTARTS(STR(?celex), "${celexPrefix}"))`,
+      `  FILTER(REGEX(STR(?celex), "${celexRegex}"))`,
       `}`,
+      // Invariant: the "-YYYYMMDD" suffix sorts lexicographically, so the largest
+      // CELEX IS the newest consolidation. DESC + LIMIT 1 returns exactly that.
       `ORDER BY DESC(?celex)`,
       `LIMIT 1`,
     ].join('\n');

--- a/src/services/cellarClient.ts
+++ b/src/services/cellarClient.ts
@@ -852,7 +852,7 @@ export class CellarClient {
     year: number,
     number: number,
     language: string,
-  ): Promise<{ content: string; eliUrl: string }> {
+  ): Promise<{ content: string; eliUrl: string; consolidatedCelex: string }> {
     // Step 1: Find consolidated CELEX ID
     const consolidatedCelex = await this.findConsolidatedCelex(docType, year, number);
 
@@ -872,6 +872,6 @@ export class CellarClient {
     });
 
     const eliUrl = `http://data.europa.eu/eli/${docType}/${year}/${number}`;
-    return { content, eliUrl };
+    return { content, eliUrl, consolidatedCelex };
   }
 }

--- a/src/services/cellarClient.ts
+++ b/src/services/cellarClient.ts
@@ -74,6 +74,7 @@ interface MetadataSparqlResponse {
       authors?: SparqlBindingValue;
       eurovoc?: SparqlBindingValue;
       dirCodes?: SparqlBindingValue;
+      legalBases?: SparqlBindingValue;
     }[];
   };
 }
@@ -419,6 +420,7 @@ export class CellarClient {
       '  (GROUP_CONCAT(DISTINCT ?authorName; separator="|||") AS ?authors)',
       '  (GROUP_CONCAT(DISTINCT ?evLabel; separator="|||") AS ?eurovoc)',
       '  (GROUP_CONCAT(DISTINCT ?dirCode; separator="|||") AS ?dirCodes)',
+      '  (GROUP_CONCAT(DISTINCT ?basisCelex; separator="|||") AS ?legalBases)',
       'WHERE {',
       `  ?work cdm:resource_legal_id_celex ?celexVal .`,
       `  FILTER(STR(?celexVal) = "${escapeSparqlString(celexId)}")`,
@@ -434,17 +436,33 @@ export class CellarClient {
       '    ?work cdm:work_has_resource-type ?resTypeUri .',
       '    BIND(REPLACE(STR(?resTypeUri), "^.*/", "") AS ?resType)',
       '  }',
+      // Authors: the agent is an authority URI (e.g. .../corporate-body/EP) whose
+      // human-readable name lives in skos:prefLabel — cdm:agent_name yields nothing
+      // (verified: it was the cause of the always-empty authors). Prefer the
+      // request-language label, fall back to English, last resort the URI tail.
       '  OPTIONAL {',
       '    ?work cdm:work_created_by_agent ?agent .',
-      '    ?agent cdm:agent_name ?authorName .',
+      `    OPTIONAL { ?agent skos:prefLabel ?agentLabelLang . FILTER(LANG(?agentLabelLang) = "${langLower}") }`,
+      '    OPTIONAL { ?agent skos:prefLabel ?agentLabelEn . FILTER(LANG(?agentLabelEn) = "en") }',
+      '    BIND(COALESCE(?agentLabelLang, ?agentLabelEn, REPLACE(STR(?agent), "^.*/", "")) AS ?authorName)',
       '  }',
       '  OPTIONAL {',
       '    ?work cdm:work_is_about_concept_eurovoc ?evConcept .',
       '    ?evConcept skos:prefLabel ?evLabel .',
       `    FILTER(LANG(?evLabel) = "${langLower}")`,
       '  }',
+      // Directory codes: emit "{code-tail}: {label}" (label in the request language),
+      // or the bare code tail when no label exists. Code tail = URI fragment after '/'.
       '  OPTIONAL {',
-      '    ?work cdm:resource_legal_is_about_concept_directory-code ?dirCode .',
+      '    ?work cdm:resource_legal_is_about_concept_directory-code ?dirCodeUri .',
+      '    BIND(REPLACE(STR(?dirCodeUri), "^.*/", "") AS ?dirTail)',
+      `    OPTIONAL { ?dirCodeUri skos:prefLabel ?dirLabel . FILTER(LANG(?dirLabel) = "${langLower}") }`,
+      '    BIND(IF(BOUND(?dirLabel), CONCAT(?dirTail, ": ", STR(?dirLabel)), ?dirTail) AS ?dirCode)',
+      '  }',
+      // Legal basis: the acts this act is based on, reported by their CELEX IDs.
+      '  OPTIONAL {',
+      '    ?work cdm:resource_legal_based_on_resource_legal ?basis .',
+      '    ?basis cdm:resource_legal_id_celex ?basisCelex .',
       '  }',
       '}',
       'GROUP BY ?title ?dateDoc ?dateForce ?dateEnd ?inForce ?dateTrans ?resType',
@@ -479,18 +497,30 @@ export class CellarClient {
       return null;
     };
 
+    // Empty/missing date strings become null (not ''); the caller can then treat
+    // "unknown" distinctly from a real date.
+    const normalizeDate = (value: string | undefined): string | null => {
+      return value ? value : null;
+    };
+
+    // Cellar uses 9999-12-31 as an "open-ended / no end of validity" sentinel.
+    // Surfacing it as a real date is misleading, so collapse it (and empties) to null.
+    const dateEnd = binding.dateEnd?.value;
+    const dateEndNormalized = !dateEnd || dateEnd === '9999-12-31' ? null : dateEnd;
+
     return {
       celex_id: celexId,
       title: binding.title?.value ?? '',
-      date_document: binding.dateDoc?.value ?? '',
-      date_entry_into_force: binding.dateForce?.value ?? '',
-      date_end_of_validity: binding.dateEnd?.value ?? '',
+      date_document: normalizeDate(binding.dateDoc?.value),
+      date_entry_into_force: normalizeDate(binding.dateForce?.value),
+      date_end_of_validity: dateEndNormalized,
       in_force: parseInForce(binding.inForce?.value),
-      date_transposition: binding.dateTrans?.value ?? '',
+      date_transposition: normalizeDate(binding.dateTrans?.value),
       resource_type: binding.resType?.value ?? '',
       authors: splitConcat(binding.authors?.value),
       eurovoc_concepts: splitConcat(binding.eurovoc?.value),
       directory_codes: splitConcat(binding.dirCodes?.value),
+      legal_basis: splitConcat(binding.legalBases?.value),
       eurlex_url: `${EURLEX_BASE}/${httpLang}/TXT/?uri=CELEX:${celexId}`,
     };
   }

--- a/src/services/cellarClient.ts
+++ b/src/services/cellarClient.ts
@@ -506,7 +506,10 @@ export class CellarClient {
   async metadataQuery(celexId: string, language: string): Promise<MetadataResult> {
     const cacheKey = `${celexId}|${language}`;
     const cached = this.metadataCache.get(cacheKey);
-    if (cached !== undefined) return cached;
+    // Shallow copy: the cache's stored object must never be the same reference
+    // as anything handed to a caller, in either direction — otherwise a caller
+    // mutating its result would silently corrupt what a later cache hit returns.
+    if (cached !== undefined) return { ...cached };
 
     const sparql = this.buildMetadataQuery(celexId, language);
 
@@ -557,7 +560,7 @@ export class CellarClient {
       eurlex_url: `${EURLEX_BASE}/${httpLang}/TXT/?uri=CELEX:${celexId}`,
     };
 
-    this.metadataCache.set(cacheKey, result);
+    this.metadataCache.set(cacheKey, { ...result });
     return result;
   }
 

--- a/src/services/cellarClient.ts
+++ b/src/services/cellarClient.ts
@@ -7,6 +7,12 @@ import {
   REQUEST_TIMEOUT_MS,
   MAX_RETRIES,
   RETRY_DELAYS_MS,
+  EUROVOC_LABEL_CACHE_TTL_MS,
+  EUROVOC_LABEL_CACHE_MAX_ENTRIES,
+  CONSOLIDATED_CELEX_CACHE_TTL_MS,
+  CONSOLIDATED_CELEX_CACHE_MAX_ENTRIES,
+  METADATA_CACHE_TTL_MS,
+  METADATA_CACHE_MAX_ENTRIES,
 } from '../constants.js';
 import type {
   SparqlQueryParams,
@@ -15,6 +21,8 @@ import type {
   CitationsResult,
   CitationEntry,
 } from '../types.js';
+
+import { TtlCache } from './ttlCache.js';
 
 /** Maps 3-letter language codes to CDM expression language URI suffixes */
 const LANGUAGE_URI_MAP: Record<string, string> = {
@@ -161,15 +169,36 @@ function isRetryableError(error: unknown): boolean {
 export interface CellarClientOptions {
   /** Injectable delay for retry backoff — defaults to a real setTimeout-based sleep. */
   retryDelayFn?: (ms: number) => Promise<void>;
+  /** Injectable clock for the TTL caches — defaults to `Date.now`. */
+  now?: () => number;
 }
 
 export class CellarClient {
   private readonly retryDelayFn: (ms: number) => Promise<void>;
 
+  // Instance-level TTL caches (Task 6) — expiry on read only, no timers.
+  // Errors are never cached; a legitimate "not found" (null) result is.
+  private readonly eurovocLabelCache: TtlCache<string | null>;
+  private readonly consolidatedCelexCache: TtlCache<string | null>;
+  private readonly metadataCache: TtlCache<MetadataResult>;
+
   constructor(options: CellarClientOptions = {}) {
     this.retryDelayFn =
       options.retryDelayFn ??
       ((ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms)));
+
+    const now = options.now ?? Date.now;
+    this.eurovocLabelCache = new TtlCache(
+      EUROVOC_LABEL_CACHE_MAX_ENTRIES,
+      EUROVOC_LABEL_CACHE_TTL_MS,
+      now,
+    );
+    this.consolidatedCelexCache = new TtlCache(
+      CONSOLIDATED_CELEX_CACHE_MAX_ENTRIES,
+      CONSOLIDATED_CELEX_CACHE_TTL_MS,
+      now,
+    );
+    this.metadataCache = new TtlCache(METADATA_CACHE_MAX_ENTRIES, METADATA_CACHE_TTL_MS, now);
   }
 
   /**
@@ -475,6 +504,10 @@ export class CellarClient {
    * Fetches metadata for a CELEX ID from the SPARQL endpoint.
    */
   async metadataQuery(celexId: string, language: string): Promise<MetadataResult> {
+    const cacheKey = `${celexId}|${language}`;
+    const cached = this.metadataCache.get(cacheKey);
+    if (cached !== undefined) return cached;
+
     const sparql = this.buildMetadataQuery(celexId, language);
 
     const data = await this.executeSparql<MetadataSparqlResponse>(sparql);
@@ -508,7 +541,7 @@ export class CellarClient {
     const dateEnd = binding.dateEnd?.value;
     const dateEndNormalized = !dateEnd || dateEnd === '9999-12-31' ? null : dateEnd;
 
-    return {
+    const result: MetadataResult = {
       celex_id: celexId,
       title: binding.title?.value ?? '',
       date_document: normalizeDate(binding.dateDoc?.value),
@@ -523,6 +556,9 @@ export class CellarClient {
       legal_basis: splitConcat(binding.legalBases?.value),
       eurlex_url: `${EURLEX_BASE}/${httpLang}/TXT/?uri=CELEX:${celexId}`,
     };
+
+    this.metadataCache.set(cacheKey, result);
+    return result;
   }
 
   /**
@@ -678,6 +714,10 @@ export class CellarClient {
    * the shortest label — a deterministic single winner instead of an arbitrary one.
    */
   async resolveEurovocLabel(label: string, language: string): Promise<string | null> {
+    const cacheKey = `${label.toLowerCase()}|${language}`;
+    const cached = this.eurovocLabelCache.get(cacheKey);
+    if (cached !== undefined) return cached;
+
     const escaped = escapeSparqlString(label);
     const langLower = LANGUAGE_HTTP_MAP[language] ?? 'de';
 
@@ -700,8 +740,10 @@ export class CellarClient {
     const bindings = data.results.bindings;
     // null means "the query succeeded and found no matching concept" — a real
     // legitimate "not found". Network/timeout/5xx errors propagate to the caller
-    // instead of being swallowed here.
-    return bindings.length > 0 ? bindings[0].concept.value : null;
+    // instead of being swallowed here (and are never cached, see below).
+    const result = bindings.length > 0 ? bindings[0].concept.value : null;
+    this.eurovocLabelCache.set(cacheKey, result);
+    return result;
   }
 
   /**
@@ -814,6 +856,10 @@ export class CellarClient {
     year: number,
     number: number,
   ): Promise<string | null> {
+    const cacheKey = `${docType}/${year}/${number}`;
+    const cached = this.consolidatedCelexCache.get(cacheKey);
+    if (cached !== undefined) return cached;
+
     const typeLetter = CellarClient.DOC_TYPE_CELEX_MAP[docType] ?? 'R';
     const celexBody = `0${year}${typeLetter}${String(number).padStart(4, '0')}`;
 
@@ -839,7 +885,11 @@ export class CellarClient {
     const data = await this.executeSparql<{
       results: { bindings: { celex: { value: string } }[] };
     }>(sparql);
-    return data.results.bindings.length > 0 ? data.results.bindings[0].celex.value : null;
+    // null is a legitimate "no consolidated version found" result — cached just
+    // like a hit, since re-querying would just re-confirm the same absence.
+    const result = data.results.bindings.length > 0 ? data.results.bindings[0].celex.value : null;
+    this.consolidatedCelexCache.set(cacheKey, result);
+    return result;
   }
 
   /**
@@ -875,3 +925,11 @@ export class CellarClient {
     return { content, eliUrl, consolidatedCelex };
   }
 }
+
+/**
+ * Shared singleton instance used by all tool handlers, so the instance-level
+ * caches (EuroVoc label resolution, consolidated CELEX lookups, metadata) are
+ * actually shared across requests within one process — a fresh `new
+ * CellarClient()` per call would make the caching above pointless.
+ */
+export const sharedCellarClient = new CellarClient();

--- a/src/services/cellarClient.ts
+++ b/src/services/cellarClient.ts
@@ -5,6 +5,8 @@ import {
   DEFAULT_LANGUAGE,
   DEFAULT_LIMIT,
   REQUEST_TIMEOUT_MS,
+  MAX_RETRIES,
+  RETRY_DELAYS_MS,
 } from '../constants.js';
 import type {
   SparqlQueryParams,
@@ -104,21 +106,105 @@ export function escapeSparqlString(input: string): string {
     .replace(/\0/g, '');
 }
 
+/**
+ * Error carrying an HTTP status code, so the retry logic can decide
+ * (based on the status alone) whether a failure is retryable.
+ */
+class HttpStatusError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+    this.name = 'HttpStatusError';
+  }
+}
+
+/** True for DOMException/Error-like objects representing an aborted/timed-out request. */
+function isTimeoutError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    (error.name === 'AbortError' || error.name === 'TimeoutError')
+  );
+}
+
+/**
+ * Decides whether a failure from executeSparql/fetchCellarDocument should be retried:
+ * network errors (TypeError from fetch), timeouts (AbortError/TimeoutError), and
+ * HTTP 5xx. Never 4xx or other errors.
+ */
+function isRetryableError(error: unknown): boolean {
+  if (error instanceof HttpStatusError) {
+    return error.status >= 500;
+  }
+  if (error instanceof TypeError) {
+    return true;
+  }
+  return isTimeoutError(error);
+}
+
+export interface CellarClientOptions {
+  /** Injectable delay for retry backoff — defaults to a real setTimeout-based sleep. */
+  retryDelayFn?: (ms: number) => Promise<void>;
+}
+
 export class CellarClient {
-  private async executeSparql<T>(sparql: string): Promise<T> {
-    const response = await fetch(SPARQL_ENDPOINT, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/sparql-query',
-        Accept: 'application/sparql-results+json',
-      },
-      body: sparql,
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-    });
-    if (!response.ok) {
-      throw new Error(`SPARQL endpoint error: ${response.status}`);
+  private readonly retryDelayFn: (ms: number) => Promise<void>;
+
+  constructor(options: CellarClientOptions = {}) {
+    this.retryDelayFn =
+      options.retryDelayFn ??
+      ((ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms)));
+  }
+
+  /**
+   * Runs `fn`, retrying on retryable failures (network errors, timeouts, HTTP 5xx)
+   * with backoff delays from RETRY_DELAYS_MS. Never retries 4xx or other errors.
+   * Rethrows the last error once retries are exhausted.
+   */
+  private async withRetry<T>(fn: () => Promise<T>): Promise<T> {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        return await fn();
+      } catch (error) {
+        if (attempt >= RETRY_DELAYS_MS.length || !isRetryableError(error)) {
+          throw error;
+        }
+        await this.retryDelayFn(RETRY_DELAYS_MS[attempt]);
+      }
     }
-    return (await response.json()) as T;
+  }
+
+  private async executeSparql<T>(sparql: string): Promise<T> {
+    try {
+      return await this.withRetry(async () => {
+        const response = await fetch(SPARQL_ENDPOINT, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/sparql-query',
+            Accept: 'application/sparql-results+json',
+          },
+          body: sparql,
+          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        });
+        if (!response.ok) {
+          throw new HttpStatusError(`SPARQL endpoint error: ${response.status}`, response.status);
+        }
+        return (await response.json()) as T;
+      });
+    } catch (error) {
+      if (isTimeoutError(error)) {
+        const seconds = Math.round(REQUEST_TIMEOUT_MS / 1000);
+        throw new Error(
+          `SPARQL query timed out after ${seconds}s (after ${MAX_RETRIES} retries). ` +
+            'The Cellar endpoint is slow for broad queries — narrow the search with resource_type, date_from/date_to, or a more specific query.',
+          { cause: error },
+        );
+      }
+      throw error;
+    }
   }
 
   /**
@@ -226,40 +312,55 @@ export class CellarClient {
   }
 
   /**
+   * Shared REST-GET logic for fetching a document from Cellar by CELEX identifier,
+   * used by both fetchDocument() and fetchConsolidated(). Handles content negotiation
+   * (Accept/Accept-Language), redirects, timeout, and 404/406/!ok status handling.
+   * Retries on network errors, timeouts, and HTTP 5xx (never on 4xx).
+   */
+  private async fetchCellarDocument(
+    celexId: string,
+    language: string,
+    context: { notFoundError: string; notAcceptableError: string },
+  ): Promise<string> {
+    const httpLang = LANGUAGE_HTTP_MAP[language] ?? 'de';
+    const url = `${CELLAR_REST_BASE}/${celexId}`;
+
+    return this.withRetry(async () => {
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          Accept: 'application/xhtml+xml',
+          'Accept-Language': httpLang,
+        },
+        redirect: 'follow',
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+
+      if (response.status === 404) {
+        throw new HttpStatusError(context.notFoundError, 404);
+      }
+
+      if (response.status === 406) {
+        throw new HttpStatusError(context.notAcceptableError, 406);
+      }
+
+      if (!response.ok) {
+        throw new HttpStatusError(`Fetch error: ${response.status}`, response.status);
+      }
+
+      return response.text();
+    });
+  }
+
+  /**
    * Fetches a document from Cellar by CELEX identifier using content negotiation.
    * Uses Accept-Language header to select the language variant.
    */
   async fetchDocument(celex_id: string, language: string): Promise<string> {
-    const httpLang = LANGUAGE_HTTP_MAP[language] ?? 'de';
-    const url = `${CELLAR_REST_BASE}/${celex_id}`;
-
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: {
-        Accept: 'application/xhtml+xml',
-        'Accept-Language': httpLang,
-      },
-      redirect: 'follow',
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    return this.fetchCellarDocument(celex_id, language, {
+      notFoundError: `Document not found: ${celex_id}. The document may not be available in electronic full-text format on EUR-Lex.`,
+      notAcceptableError: `Document ${celex_id} is not available in XHTML format. Older documents may only exist as PDF on EUR-Lex.`,
     });
-
-    if (response.status === 404) {
-      throw new Error(
-        `Document not found: ${celex_id}. The document may not be available in electronic full-text format on EUR-Lex.`,
-      );
-    }
-
-    if (response.status === 406) {
-      throw new Error(
-        `Document ${celex_id} is not available in XHTML format. Older documents may only exist as PDF on EUR-Lex.`,
-      );
-    }
-
-    if (!response.ok) {
-      throw new Error(`Fetch error: ${response.status}`);
-    }
-
-    return response.text();
   }
 
   /**
@@ -483,16 +584,14 @@ export class CellarClient {
       'LIMIT 1',
     ].join('\n');
 
-    try {
-      const data = await this.executeSparql<{
-        results: { bindings: { concept: { value: string } }[] };
-      }>(sparql);
-      const bindings = data.results.bindings;
-      return bindings.length > 0 ? bindings[0].concept.value : null;
-    } catch {
-      // Timeout or SPARQL error during label resolution — return null to indicate no match
-      return null;
-    }
+    const data = await this.executeSparql<{
+      results: { bindings: { concept: { value: string } }[] };
+    }>(sparql);
+    const bindings = data.results.bindings;
+    // null means "the query succeeded and found no matching concept" — a real
+    // legitimate "not found". Network/timeout/5xx errors propagate to the caller
+    // instead of being swallowed here.
+    return bindings.length > 0 ? bindings[0].concept.value : null;
   }
 
   /**
@@ -640,39 +739,20 @@ export class CellarClient {
 
     if (!consolidatedCelex) {
       throw new Error(
-        `Keine konsolidierte Fassung für ${docType}/${year}/${number} verfügbar. ` +
-          `Verwenden Sie eurlex_fetch mit der CELEX-ID für die Original-OJ-Version.`,
+        `No consolidated version available for ${docType}/${year}/${number}. ` +
+          'Use eurlex_fetch with the CELEX ID for the original OJ version.',
       );
     }
 
-    // Step 2: Fetch from Cellar REST (same as fetchDocument)
-    const httpLang = LANGUAGE_HTTP_MAP[language] ?? 'de';
-    const url = `${CELLAR_REST_BASE}/${consolidatedCelex}`;
-
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: {
-        Accept: 'application/xhtml+xml',
-        'Accept-Language': httpLang,
-      },
-      redirect: 'follow',
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    // Step 2: Fetch from Cellar REST via the shared helper (same as fetchDocument)
+    const content = await this.fetchCellarDocument(consolidatedCelex, language, {
+      notFoundError:
+        `No consolidated version available for ${docType}/${year}/${number} (${consolidatedCelex} could not be retrieved). ` +
+        'Use eurlex_fetch with the CELEX ID for the original OJ version.',
+      notAcceptableError: `Consolidated document ${consolidatedCelex} is not available in XHTML format. Older documents may only exist as PDF on EUR-Lex.`,
     });
 
-    if (response.status === 404) {
-      throw new Error(
-        `Keine konsolidierte Fassung für ${docType}/${year}/${number} verfügbar (${consolidatedCelex} nicht abrufbar). ` +
-          `Verwenden Sie eurlex_fetch mit der CELEX-ID für die Original-OJ-Version.`,
-      );
-    }
-
-    if (!response.ok) {
-      throw new Error(
-        `Consolidated document error: ${docType}/${year}/${number} (HTTP ${response.status})`,
-      );
-    }
-
     const eliUrl = `http://data.europa.eu/eli/${docType}/${year}/${number}`;
-    return { content: await response.text(), eliUrl };
+    return { content, eliUrl };
   }
 }

--- a/src/services/ttlCache.ts
+++ b/src/services/ttlCache.ts
@@ -1,0 +1,46 @@
+/**
+ * Small in-memory TTL cache with FIFO (insertion-order) eviction beyond
+ * `maxEntries`. Expiry is checked lazily on `get()` only — there is no
+ * background timer/interval, so it never keeps the stdio process alive.
+ *
+ * Insertion-ordered `Map` gives FIFO for free: re-assigning an *existing* key
+ * keeps its original position, so eviction always removes the entry that was
+ * first inserted (not the least-recently-used one).
+ */
+export class TtlCache<V> {
+  private readonly store = new Map<string, { value: V; expiresAt: number }>();
+
+  constructor(
+    private readonly maxEntries: number,
+    private readonly ttlMs: number,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  /**
+   * Returns the cached value, or `undefined` on a miss (never stored, or
+   * expired). A cached `undefined`-vs-`V` distinction is up to the caller —
+   * this cache stores whatever `V` is, including `null`, and only ever
+   * returns `undefined` to signal "not in cache".
+   */
+  get(key: string): V | undefined {
+    const entry = this.store.get(key);
+    if (!entry) return undefined;
+
+    if (this.now() >= entry.expiresAt) {
+      this.store.delete(key);
+      return undefined;
+    }
+
+    return entry.value;
+  }
+
+  set(key: string, value: V): void {
+    this.store.set(key, { value, expiresAt: this.now() + this.ttlMs });
+
+    while (this.store.size > this.maxEntries) {
+      const oldestKey = this.store.keys().next().value;
+      if (oldestKey === undefined) break;
+      this.store.delete(oldestKey);
+    }
+  }
+}

--- a/src/tools/citations.ts
+++ b/src/tools/citations.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { citationsSchema } from '../schemas/citationsSchema.js';
-import { CellarClient } from '../services/cellarClient.js';
+import { sharedCellarClient } from '../services/cellarClient.js';
 import { toolError } from '../utils.js';
 
 export async function handleEurlexCitations(input: {
@@ -11,8 +11,7 @@ export async function handleEurlexCitations(input: {
   limit: number;
 }): Promise<{ content: { type: 'text'; text: string }[]; isError?: true }> {
   try {
-    const client = new CellarClient();
-    const result = await client.citationsQuery(
+    const result = await sharedCellarClient.citationsQuery(
       input.celex_id,
       input.language,
       input.direction,

--- a/src/tools/citations.ts
+++ b/src/tools/citations.ts
@@ -45,7 +45,7 @@ export async function handleEurlexCitations(input: {
 export function registerCitationsTool(server: McpServer): void {
   server.tool(
     'eurlex_citations',
-    'Finds citation relationships for an EU legal act: cites, cited_by, amends/amended_by, based_on/basis_for, repeals/repealed_by. direction="both" runs a balanced split so recent cited_by entries cannot crowd out cites results; the response\'s counts field reports how many of each side were found.',
+    'Finds citation relationships for an EU legal act: cites, cited_by, amends/amended_by, based_on/basis_for, repeals/repealed_by. direction="both" runs a balanced split so recent cited_by entries cannot crowd out cites results; the response\'s counts field reports how many of each side were found. The limit is divided evenly between the two directions and is not back-filled from the richer side, so direction="both" can return fewer than `limit` total results even when one side has more matches available.',
     citationsSchema.shape,
     {
       title: 'Find EU legal act citations',

--- a/src/tools/citations.ts
+++ b/src/tools/citations.ts
@@ -11,13 +11,12 @@ export async function handleEurlexCitations(input: {
   limit: number;
 }): Promise<{ content: { type: 'text'; text: string }[]; isError?: true }> {
   try {
-    const parsed = citationsSchema.parse(input);
     const client = new CellarClient();
     const result = await client.citationsQuery(
-      parsed.celex_id,
-      parsed.language,
-      parsed.direction,
-      parsed.limit,
+      input.celex_id,
+      input.language,
+      input.direction,
+      input.limit,
     );
 
     if (result.citations.length === 0) {
@@ -25,7 +24,7 @@ export async function handleEurlexCitations(input: {
         content: [
           {
             type: 'text' as const,
-            text: `Keine Zitierungen gefunden für CELEX: ${parsed.celex_id}`,
+            text: `No citations found for CELEX: ${input.celex_id}`,
           },
         ],
       };
@@ -47,9 +46,15 @@ export async function handleEurlexCitations(input: {
 export function registerCitationsTool(server: McpServer): void {
   server.tool(
     'eurlex_citations',
-    'Findet Zitierungen, Rechtsgrundlagen und Änderungen eines EU-Rechtsakts',
+    'Finds citation relationships for an EU legal act: cites, cited_by, amends/amended_by, based_on/basis_for, repeals/repealed_by. direction="both" runs a balanced split so recent cited_by entries cannot crowd out cites results; the response\'s counts field reports how many of each side were found.',
     citationsSchema.shape,
-    { readOnlyHint: true, destructiveHint: false },
+    {
+      title: 'Find EU legal act citations',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async (params) => handleEurlexCitations(params),
   );
 }

--- a/src/tools/consolidated.ts
+++ b/src/tools/consolidated.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { consolidatedInputSchema, consolidatedSchema } from '../schemas/consolidatedSchema.js';
-import { CellarClient } from '../services/cellarClient.js';
+import { sharedCellarClient } from '../services/cellarClient.js';
 import type { ConsolidatedResult } from '../types.js';
 import { processContent, toolError } from '../utils.js';
 
@@ -74,12 +74,11 @@ export async function handleEurlexConsolidated(input: {
       number = parsed.number as number;
     }
 
-    const client = new CellarClient();
     const {
       content: rawContent,
       eliUrl,
       consolidatedCelex,
-    } = await client.fetchConsolidated(docType, year, number, parsed.language);
+    } = await sharedCellarClient.fetchConsolidated(docType, year, number, parsed.language);
 
     const { content, truncated, returned_chars, total_chars, offset, next_offset } = processContent(
       rawContent,

--- a/src/tools/consolidated.ts
+++ b/src/tools/consolidated.ts
@@ -5,6 +5,18 @@ import { CellarClient } from '../services/cellarClient.js';
 import type { ConsolidatedResult } from '../types.js';
 import { processContent, toolError } from '../utils.js';
 
+/**
+ * Parses the "-YYYYMMDD" consolidation-date suffix off a consolidated CELEX
+ * ID, e.g. "02016R0679-20160504" -> "2016-05-04". Returns `null` when the
+ * CELEX has no such suffix.
+ */
+function parseConsolidationDate(consolidatedCelex: string): string | null {
+  const match = /-(\d{4})(\d{2})(\d{2})$/.exec(consolidatedCelex);
+  if (!match) return null;
+  const [, year, month, day] = match;
+  return `${year}-${month}-${day}`;
+}
+
 export async function handleEurlexConsolidated(input: {
   doc_type: string;
   year: number;
@@ -12,22 +24,28 @@ export async function handleEurlexConsolidated(input: {
   language: string;
   format: 'plain' | 'xhtml';
   max_chars: number;
+  offset: number;
 }): Promise<{ content: { type: 'text'; text: string }[]; isError?: true }> {
   try {
     const parsed = consolidatedSchema.parse(input);
 
     const client = new CellarClient();
-    const { content: rawContent, eliUrl } = await client.fetchConsolidated(
+    const {
+      content: rawContent,
+      eliUrl,
+      consolidatedCelex,
+    } = await client.fetchConsolidated(
       parsed.doc_type,
       parsed.year,
       parsed.number,
       parsed.language,
     );
 
-    const { content, truncated, charCount } = processContent(
+    const { content, truncated, returned_chars, total_chars, offset, next_offset } = processContent(
       rawContent,
       parsed.format,
       parsed.max_chars,
+      parsed.offset,
     );
 
     const result: ConsolidatedResult = {
@@ -37,8 +55,13 @@ export async function handleEurlexConsolidated(input: {
       language: parsed.language,
       content,
       truncated,
-      char_count: charCount,
+      returned_chars,
+      total_chars,
+      offset,
+      next_offset,
       eli_url: eliUrl,
+      consolidated_celex: consolidatedCelex,
+      consolidation_date: parseConsolidationDate(consolidatedCelex),
     };
 
     return {

--- a/src/tools/consolidated.ts
+++ b/src/tools/consolidated.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
-import { consolidatedSchema } from '../schemas/consolidatedSchema.js';
+import { consolidatedInputSchema, consolidatedSchema } from '../schemas/consolidatedSchema.js';
 import { CellarClient } from '../services/cellarClient.js';
 import type { ConsolidatedResult } from '../types.js';
 import { processContent, toolError } from '../utils.js';
@@ -17,29 +17,69 @@ function parseConsolidationDate(consolidatedCelex: string): string | null {
   return `${year}-${month}-${day}`;
 }
 
+// Sector-3 secondary-law CELEX pattern: 3 (sector) + YYYY (year) + R|L|D
+// (type letter) + NNNN+ (document number). Used to derive doc_type/year/number
+// from a celex_id input — the alternative to doc_type + year + number.
+const SECTOR3_CELEX_REGEX = /^3(\d{4})([RLD])(\d+)$/;
+const TYPE_LETTER_TO_DOC_TYPE: Record<string, 'reg' | 'dir' | 'dec'> = {
+  R: 'reg',
+  L: 'dir',
+  D: 'dec',
+};
+
+function deriveFromCelex(celexId: string): { docType: string; year: number; number: number } {
+  const match = SECTOR3_CELEX_REGEX.exec(celexId);
+  if (!match) {
+    throw new Error(
+      `celex_id "${celexId}" is not a sector-3 secondary-law CELEX. Expected format 3YYYY[R|L|D]NNNN, e.g. "32016R0679" (GDPR: R=regulation, L=directive, D=decision). Use doc_type/year/number instead, or eurlex_fetch/eurlex_metadata for other sectors.`,
+    );
+  }
+  const [, yearStr, typeLetter, numberStr] = match;
+  return {
+    docType: TYPE_LETTER_TO_DOC_TYPE[typeLetter],
+    year: Number(yearStr),
+    number: Number(numberStr),
+  };
+}
+
 export async function handleEurlexConsolidated(input: {
-  doc_type: string;
-  year: number;
-  number: number;
+  celex_id?: string;
+  doc_type?: string;
+  year?: number;
+  number?: number;
   language: string;
   format: 'plain' | 'xhtml';
   max_chars: number;
   offset: number;
 }): Promise<{ content: { type: 'text'; text: string }[]; isError?: true }> {
   try {
-    const parsed = consolidatedSchema.parse(input);
+    // `server.tool(consolidatedSchema.shape)` only registers the per-field
+    // shape with the SDK — the celex_id XOR doc_type+year+number invariant is
+    // an object-level refinement that gets stripped in that process. Re-parse
+    // against the refined schema here so the invariant is actually enforced.
+    const parsed = consolidatedInputSchema.parse(input);
+
+    let docType: string;
+    let year: number;
+    let number: number;
+    if (parsed.celex_id) {
+      const derived = deriveFromCelex(parsed.celex_id);
+      docType = derived.docType;
+      year = derived.year;
+      number = derived.number;
+    } else {
+      // Guaranteed defined here by the XOR refinement above.
+      docType = parsed.doc_type as string;
+      year = parsed.year as number;
+      number = parsed.number as number;
+    }
 
     const client = new CellarClient();
     const {
       content: rawContent,
       eliUrl,
       consolidatedCelex,
-    } = await client.fetchConsolidated(
-      parsed.doc_type,
-      parsed.year,
-      parsed.number,
-      parsed.language,
-    );
+    } = await client.fetchConsolidated(docType, year, number, parsed.language);
 
     const { content, truncated, returned_chars, total_chars, offset, next_offset } = processContent(
       rawContent,
@@ -49,9 +89,9 @@ export async function handleEurlexConsolidated(input: {
     );
 
     const result: ConsolidatedResult = {
-      doc_type: parsed.doc_type,
-      year: parsed.year,
-      number: parsed.number,
+      doc_type: docType,
+      year,
+      number,
       language: parsed.language,
       content,
       truncated,
@@ -80,9 +120,15 @@ export async function handleEurlexConsolidated(input: {
 export function registerConsolidatedTool(server: McpServer): void {
   server.tool(
     'eurlex_consolidated',
-    'Ruft die konsolidierte (aktuell gültige) Fassung eines EU-Rechtsakts ab via ELI',
+    'Fetches the latest consolidated (currently in-force) version of an EU legal act via ELI, with all amendments merged in. Identify the act with celex_id (e.g. "32016R0679") OR with doc_type + year + number — provide exactly one of the two. celex_id must be a sector-3 secondary-law CELEX (3YYYY[R|L|D]NNNN).',
     consolidatedSchema.shape,
-    { readOnlyHint: true, destructiveHint: false },
+    {
+      title: 'Get consolidated EU legal act',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async (params) => handleEurlexConsolidated(params),
   );
 }

--- a/src/tools/eurovoc.ts
+++ b/src/tools/eurovoc.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { eurovocSchema } from '../schemas/eurovocSchema.js';
-import { CellarClient } from '../services/cellarClient.js';
+import { sharedCellarClient } from '../services/cellarClient.js';
 import { toolError } from '../utils.js';
 
 export async function handleEurlexByEurovoc(input: {
@@ -11,8 +11,7 @@ export async function handleEurlexByEurovoc(input: {
   limit: number;
 }): Promise<{ content: { type: 'text'; text: string }[]; isError?: true }> {
   try {
-    const client = new CellarClient();
-    const results = await client.eurovocQuery(
+    const results = await sharedCellarClient.eurovocQuery(
       input.concept,
       input.resource_type,
       input.language,

--- a/src/tools/eurovoc.ts
+++ b/src/tools/eurovoc.ts
@@ -11,13 +11,12 @@ export async function handleEurlexByEurovoc(input: {
   limit: number;
 }): Promise<{ content: { type: 'text'; text: string }[]; isError?: true }> {
   try {
-    const parsed = eurovocSchema.parse(input);
     const client = new CellarClient();
     const results = await client.eurovocQuery(
-      parsed.concept,
-      parsed.resource_type,
-      parsed.language,
-      parsed.limit,
+      input.concept,
+      input.resource_type,
+      input.language,
+      input.limit,
     );
 
     if (results.length === 0) {
@@ -25,7 +24,7 @@ export async function handleEurlexByEurovoc(input: {
         content: [
           {
             type: 'text' as const,
-            text: `Keine Ergebnisse für EuroVoc-Konzept "${parsed.concept}"`,
+            text: `No results for EuroVoc concept "${input.concept}"`,
           },
         ],
       };
@@ -47,9 +46,15 @@ export async function handleEurlexByEurovoc(input: {
 export function registerEurovocTool(server: McpServer): void {
   server.tool(
     'eurlex_by_eurovoc',
-    'Sucht EU-Rechtsakte nach EuroVoc-Thema (z.B. "artificial intelligence", "data protection")',
+    'Searches EU legal acts by EuroVoc thematic concept — the right tool for "documents about X" when the term may not appear in the title. Accepts a concept label (e.g. "artificial intelligence") or a EuroVoc URI.',
     eurovocSchema.shape,
-    { readOnlyHint: true, destructiveHint: false },
+    {
+      title: 'Search EU law by topic',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async (params) => handleEurlexByEurovoc(params),
   );
 }

--- a/src/tools/fetch.ts
+++ b/src/tools/fetch.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { CELLAR_REST_BASE } from '../constants.js';
 import { fetchSchema } from '../schemas/fetchSchema.js';
-import { CellarClient } from '../services/cellarClient.js';
+import { sharedCellarClient } from '../services/cellarClient.js';
 import type { FetchResult } from '../types.js';
 import { processContent, toolError } from '../utils.js';
 
@@ -14,8 +14,7 @@ export async function handleEurlexFetch(input: {
   offset: number;
 }): Promise<{ content: { type: 'text'; text: string }[]; isError?: true }> {
   try {
-    const client = new CellarClient();
-    const raw = await client.fetchDocument(input.celex_id, input.language);
+    const raw = await sharedCellarClient.fetchDocument(input.celex_id, input.language);
     const { content, truncated, returned_chars, total_chars, offset, next_offset } = processContent(
       raw,
       input.format,

--- a/src/tools/fetch.ts
+++ b/src/tools/fetch.ts
@@ -14,27 +14,25 @@ export async function handleEurlexFetch(input: {
   offset: number;
 }): Promise<{ content: { type: 'text'; text: string }[]; isError?: true }> {
   try {
-    const parsed = fetchSchema.parse(input);
-
     const client = new CellarClient();
-    const raw = await client.fetchDocument(parsed.celex_id, parsed.language);
+    const raw = await client.fetchDocument(input.celex_id, input.language);
     const { content, truncated, returned_chars, total_chars, offset, next_offset } = processContent(
       raw,
-      parsed.format,
-      parsed.max_chars,
-      parsed.offset,
+      input.format,
+      input.max_chars,
+      input.offset,
     );
 
     const result: FetchResult = {
-      celex_id: parsed.celex_id,
-      language: parsed.language,
+      celex_id: input.celex_id,
+      language: input.language,
       content,
       truncated,
       returned_chars,
       total_chars,
       offset,
       next_offset,
-      source_url: `${CELLAR_REST_BASE}/${parsed.celex_id}`,
+      source_url: `${CELLAR_REST_BASE}/${input.celex_id}`,
     };
 
     return {
@@ -53,9 +51,15 @@ export async function handleEurlexFetch(input: {
 export function registerFetchTool(server: McpServer): void {
   server.tool(
     'eurlex_fetch',
-    'Ruft Volltext eines EU-Rechtsakts per CELEX-ID ab',
+    "Fetches the full text of an EU legal act by CELEX ID. Paginate long documents with offset and max_chars: pass the previous response's next_offset to continue reading until it is null.",
     fetchSchema.shape,
-    { readOnlyHint: true, destructiveHint: false },
+    {
+      title: 'Fetch EU legal act full text',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async (params) => handleEurlexFetch(params),
   );
 }

--- a/src/tools/fetch.ts
+++ b/src/tools/fetch.ts
@@ -1,7 +1,9 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
+import { CELLAR_REST_BASE } from '../constants.js';
 import { fetchSchema } from '../schemas/fetchSchema.js';
 import { CellarClient } from '../services/cellarClient.js';
+import type { FetchResult } from '../types.js';
 import { processContent, toolError } from '../utils.js';
 
 export async function handleEurlexFetch(input: {
@@ -9,26 +11,37 @@ export async function handleEurlexFetch(input: {
   language: string;
   format: 'plain' | 'xhtml';
   max_chars: number;
+  offset: number;
 }): Promise<{ content: { type: 'text'; text: string }[]; isError?: true }> {
   try {
     const parsed = fetchSchema.parse(input);
 
     const client = new CellarClient();
     const raw = await client.fetchDocument(parsed.celex_id, parsed.language);
-    const { content, truncated, charCount } = processContent(raw, parsed.format, parsed.max_chars);
+    const { content, truncated, returned_chars, total_chars, offset, next_offset } = processContent(
+      raw,
+      parsed.format,
+      parsed.max_chars,
+      parsed.offset,
+    );
+
+    const result: FetchResult = {
+      celex_id: parsed.celex_id,
+      language: parsed.language,
+      content,
+      truncated,
+      returned_chars,
+      total_chars,
+      offset,
+      next_offset,
+      source_url: `${CELLAR_REST_BASE}/${parsed.celex_id}`,
+    };
 
     return {
       content: [
         {
           type: 'text' as const,
-          text: JSON.stringify({
-            celex_id: parsed.celex_id,
-            language: parsed.language,
-            content,
-            truncated,
-            char_count: charCount,
-            source_url: `https://publications.europa.eu/resource/celex/${parsed.celex_id}`,
-          }),
+          text: JSON.stringify(result),
         },
       ],
     };

--- a/src/tools/metadata.ts
+++ b/src/tools/metadata.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { metadataSchema } from '../schemas/metadataSchema.js';
-import { CellarClient } from '../services/cellarClient.js';
+import { sharedCellarClient } from '../services/cellarClient.js';
 import { toolError } from '../utils.js';
 
 export async function handleEurlexMetadata(input: {
@@ -9,8 +9,7 @@ export async function handleEurlexMetadata(input: {
   language: string;
 }): Promise<{ content: { type: 'text'; text: string }[]; isError?: true }> {
   try {
-    const client = new CellarClient();
-    const result = await client.metadataQuery(input.celex_id, input.language);
+    const result = await sharedCellarClient.metadataQuery(input.celex_id, input.language);
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(result) }],
     };

--- a/src/tools/metadata.ts
+++ b/src/tools/metadata.ts
@@ -9,9 +9,8 @@ export async function handleEurlexMetadata(input: {
   language: string;
 }): Promise<{ content: { type: 'text'; text: string }[]; isError?: true }> {
   try {
-    const parsed = metadataSchema.parse(input);
     const client = new CellarClient();
-    const result = await client.metadataQuery(parsed.celex_id, parsed.language);
+    const result = await client.metadataQuery(input.celex_id, input.language);
     return {
       content: [{ type: 'text' as const, text: JSON.stringify(result) }],
     };
@@ -23,9 +22,15 @@ export async function handleEurlexMetadata(input: {
 export function registerMetadataTool(server: McpServer): void {
   server.tool(
     'eurlex_metadata',
-    'Ruft detaillierte Metadaten eines EU-Rechtsakts per CELEX-ID ab (Daten, Autoren, EuroVoc, Directory-Codes)',
+    'Fetches metadata for an EU legal act by CELEX ID: document/entry-into-force/end-of-validity dates, in-force status, authors, legal basis (CELEX IDs of the acts it is based on), EuroVoc descriptors, and directory codes.',
     metadataSchema.shape,
-    { readOnlyHint: true, destructiveHint: false },
+    {
+      title: 'Get EU legal act metadata',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async (params) => handleEurlexMetadata(params),
   );
 }

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -25,7 +25,7 @@ export async function handleEurlexSearch(input: {
 
     if (results.length === 0) {
       return {
-        content: [{ type: 'text' as const, text: `Keine Ergebnisse für "${input.query}"` }],
+        content: [{ type: 'text' as const, text: `No results for "${input.query}"` }],
       };
     }
 
@@ -47,9 +47,15 @@ export async function handleEurlexSearch(input: {
 export function registerSearchTool(server: McpServer): void {
   server.tool(
     'eurlex_search',
-    'Sucht EU-Rechtsakte nach Titel via EUR-Lex SPARQL',
+    'Searches EU legal acts by title substring (contiguous phrase, case-insensitive — not tokenized full-text search). For topic-based discovery use eurlex_by_eurovoc instead. Broad single-word terms can be slow; narrow with resource_type or date_from/date_to. Supported languages: German, English, French. Results are newest-first within the fetched sample, not necessarily the globally newest match for very broad queries.',
     searchSchema.shape,
-    { readOnlyHint: true, destructiveHint: false },
+    {
+      title: 'Search EU law by title',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     async (params) => handleEurlexSearch(params),
   );
 }

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -2,6 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { searchSchema } from '../schemas/searchSchema.js';
 import { CellarClient } from '../services/cellarClient.js';
+import type { SearchToolOutput } from '../types.js';
 import { toolError } from '../utils.js';
 
 export async function handleEurlexSearch(input: {
@@ -14,7 +15,7 @@ export async function handleEurlexSearch(input: {
 }): Promise<{ content: { type: 'text'; text: string }[]; isError?: true }> {
   try {
     const client = new CellarClient();
-    const { results, sparql } = await client.sparqlQuery(input.query, {
+    const { results } = await client.sparqlQuery(input.query, {
       resource_type: input.resource_type,
       language: input.language,
       limit: input.limit,
@@ -28,11 +29,13 @@ export async function handleEurlexSearch(input: {
       };
     }
 
+    const output: SearchToolOutput = { results, total: results.length };
+
     return {
       content: [
         {
           type: 'text' as const,
-          text: JSON.stringify({ results, total: results.length, query_used: sparql }),
+          text: JSON.stringify(output),
         },
       ],
     };

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { searchSchema } from '../schemas/searchSchema.js';
-import { CellarClient } from '../services/cellarClient.js';
+import { sharedCellarClient } from '../services/cellarClient.js';
 import type { SearchToolOutput } from '../types.js';
 import { toolError } from '../utils.js';
 
@@ -14,8 +14,7 @@ export async function handleEurlexSearch(input: {
   date_to?: string;
 }): Promise<{ content: { type: 'text'; text: string }[]; isError?: true }> {
   try {
-    const client = new CellarClient();
-    const { results } = await client.sparqlQuery(input.query, {
+    const { results } = await sharedCellarClient.sparqlQuery(input.query, {
       resource_type: input.resource_type,
       language: input.language,
       limit: input.limit,

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,12 @@ export interface CitationsResult {
   celex_id: string;
   citations: CitationEntry[];
   total: number;
+  /**
+   * How the returned citations split across the two directions.
+   * `cites` counts cites/based_on/amends/repeals rows (this act references others);
+   * `cited_by` counts the inverse rows (other acts reference this one).
+   */
+  counts: { cites: number; cited_by: number };
 }
 
 export interface ConsolidatedResult {

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,15 +19,22 @@ export interface FetchResult {
   celex_id: string;
   language: string;
   content: string;
+  /** True when more content remains beyond `offset + returned_chars`. */
   truncated: boolean;
-  char_count: number;
+  /** Length of `content` in this response. */
+  returned_chars: number;
+  /** Length of the full processed (post-strip) document. */
+  total_chars: number;
+  /** The offset this response was sliced from. */
+  offset: number;
+  /** Offset to request next to continue reading, or `null` when there is no more content. */
+  next_offset: number | null;
   source_url: string;
 }
 
 export interface SearchToolOutput {
   results: SearchResult[];
   total: number;
-  query_used: string;
 }
 
 export interface MetadataResult {
@@ -87,7 +94,19 @@ export interface ConsolidatedResult {
   number: number;
   language: string;
   content: string;
+  /** True when more content remains beyond `offset + returned_chars`. */
   truncated: boolean;
-  char_count: number;
+  /** Length of `content` in this response. */
+  returned_chars: number;
+  /** Length of the full processed (post-strip) document. */
+  total_chars: number;
+  /** The offset this response was sliced from. */
+  offset: number;
+  /** Offset to request next to continue reading, or `null` when there is no more content. */
+  next_offset: number | null;
   eli_url: string;
+  /** The resolved consolidated CELEX ID, e.g. "02016R0679-20160504". */
+  consolidated_celex: string;
+  /** ISO date parsed from the CELEX's "-YYYYMMDD" suffix, or `null` when absent. */
+  consolidation_date: string | null;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,15 +33,22 @@ export interface SearchToolOutput {
 export interface MetadataResult {
   celex_id: string;
   title: string;
-  date_document: string;
-  date_entry_into_force: string;
-  date_end_of_validity: string;
+  /** ISO date, or null when absent. */
+  date_document: string | null;
+  /** ISO date, or null when absent. */
+  date_entry_into_force: string | null;
+  /** ISO date, or null when absent OR when it is the Cellar `9999-12-31` sentinel. */
+  date_end_of_validity: string | null;
   in_force: boolean | null;
-  date_transposition: string;
+  /** ISO date, or null when absent. */
+  date_transposition: string | null;
   resource_type: string;
   authors: string[];
   eurovoc_concepts: string[];
+  /** Directory-code entries as `"{code-tail}: {label}"`, or the bare code tail when unlabelled. */
   directory_codes: string[];
+  /** CELEX IDs of the legal acts this act is based on (its legal basis). */
+  legal_basis: string[];
   eurlex_url: string;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,38 @@
+/** HTML entity decodings applied after tag stripping. `&amp;` must run last so
+ * an already-literal sequence like `&amp;lt;` (representing the text `&lt;`)
+ * is not double-decoded into `<`. */
+const ENTITY_REPLACEMENTS: [RegExp, string][] = [
+  [/&nbsp;|&#160;/gi, ' '],
+  [/&lt;/gi, '<'],
+  [/&gt;/gi, '>'],
+  [/&quot;/gi, '"'],
+  [/&#39;|&apos;/gi, "'"],
+  [/&amp;/gi, '&'],
+];
+
+/**
+ * Converts HTML/XHTML into compact plain text: strips tags, decodes common
+ * entities, collapses runs of horizontal whitespace, trims trailing
+ * whitespace per line, and collapses 3+ consecutive newlines to 2.
+ *
+ * Live finding: EUR-Lex table-layout markup (e.g. GDPR) renders as long runs
+ * of blank lines once tags are removed — collapsing those is the single
+ * biggest token saving for `plain` format output.
+ */
 export function stripHtml(content: string): string {
-  return content
+  let text = content
     .replace(/<script[\s\S]*?<\/script>/gi, '')
     .replace(/<style[\s\S]*?<\/style>/gi, '')
     .replace(/<[^>]*>/g, '');
+
+  for (const [pattern, replacement] of ENTITY_REPLACEMENTS) {
+    text = text.replace(pattern, replacement);
+  }
+
+  return text
+    .replace(/[ \t]+/g, ' ')
+    .replace(/[ \t]+$/gm, '')
+    .replace(/\n{3,}/g, '\n\n');
 }
 
 export function toolError(error: unknown): {
@@ -16,14 +46,36 @@ export function toolError(error: unknown): {
   };
 }
 
+export interface ProcessedContent {
+  content: string;
+  truncated: boolean;
+  /** Length of `content` in this response. */
+  returned_chars: number;
+  /** Length of the full processed (post-strip) document. */
+  total_chars: number;
+  /** The offset this response was sliced from. */
+  offset: number;
+  /** Offset to request next to continue reading, or `null` when there is no more content. */
+  next_offset: number | null;
+}
+
+/**
+ * Processes raw document content for a tool response: strips HTML first (for
+ * `plain` format), then slices out an `[offset, offset + maxChars)` window of
+ * the processed text. Offsets at or beyond the end of the document return
+ * empty content with `truncated: false`.
+ */
 export function processContent(
   raw: string,
   format: 'plain' | 'xhtml',
   maxChars: number,
-): { content: string; truncated: boolean; charCount: number } {
-  let content = format === 'plain' ? stripHtml(raw) : raw;
-  const charCount = content.length;
-  const truncated = charCount > maxChars;
-  if (truncated) content = content.slice(0, maxChars);
-  return { content, truncated, charCount };
+  offset = 0,
+): ProcessedContent {
+  const processed = format === 'plain' ? stripHtml(raw) : raw;
+  const total_chars = processed.length;
+  const content = processed.slice(offset, offset + maxChars);
+  const returned_chars = content.length;
+  const truncated = offset + returned_chars < total_chars;
+  const next_offset = truncated ? offset + returned_chars : null;
+  return { content, truncated, returned_chars, total_chars, offset, next_offset };
 }

--- a/tests/cellarClient.citations.test.ts
+++ b/tests/cellarClient.citations.test.ts
@@ -53,7 +53,8 @@ describe('buildCitationsQuery()', () => {
 
 describe('citationsQuery()', () => {
   it('C9 – returns CitationsResult with parsed citation entries', async () => {
-    const sparqlResponse = {
+    // direction 'both' runs two directional queries: cites-side + cited_by-side.
+    const citesResponse = {
       results: {
         bindings: [{
           celex: { type: 'literal', value: '32016R0679' },
@@ -64,11 +65,11 @@ describe('citationsQuery()', () => {
         }],
       },
     }
+    const citedByResponse = { results: { bindings: [] } }
 
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => sparqlResponse,
-    })
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => citesResponse })
+      .mockResolvedValueOnce({ ok: true, json: async () => citedByResponse })
 
     const client = new CellarClient()
     const result = await client.citationsQuery('32024R1689', 'DEU', 'both', 20)
@@ -77,6 +78,7 @@ describe('citationsQuery()', () => {
     expect(result.citations).toHaveLength(1)
     expect(result.citations[0].celex).toBe('32016R0679')
     expect(result.citations[0].relationship).toBe('cites')
+    expect(result.counts).toEqual({ cites: 1, cited_by: 0 })
   })
 
   it('C9a – throws on unexpected relationship value', async () => {
@@ -100,7 +102,8 @@ describe('citationsQuery()', () => {
   })
 
   it('C10 – returns empty citations array when no relationships found', async () => {
-    mockFetch.mockResolvedValueOnce({
+    // Both directional queries (cites + cited_by) return nothing.
+    mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({ results: { bindings: [] } }),
     })
@@ -110,6 +113,7 @@ describe('citationsQuery()', () => {
 
     expect(result.citations).toEqual([])
     expect(result.total).toBe(0)
+    expect(result.counts).toEqual({ cites: 0, cited_by: 0 })
   })
 })
 

--- a/tests/cellarClient.consolidated.test.ts
+++ b/tests/cellarClient.consolidated.test.ts
@@ -66,7 +66,7 @@ describe('fetchConsolidated()', () => {
     expect((opts2.headers as Record<string, string>)['Accept-Language']).toBe('de')
   })
 
-  it('CO5 – returns content and eliUrl', async () => {
+  it('CO5 – returns content, eliUrl and consolidatedCelex', async () => {
     mockFetch
       .mockResolvedValueOnce(mockSparqlCelexResponse('02022L2555-20230101'))
       .mockResolvedValueOnce(mockDocumentResponse('<html><body>Artikel 1</body></html>'))
@@ -76,6 +76,7 @@ describe('fetchConsolidated()', () => {
 
     expect(result.content).toContain('Artikel 1')
     expect(result.eliUrl).toContain('data.europa.eu/eli/dir/2022/2555')
+    expect(result.consolidatedCelex).toBe('02022L2555-20230101')
   })
 
   it('CO6 – throws when no consolidated CELEX found via SPARQL', async () => {

--- a/tests/cellarClient.consolidated.test.ts
+++ b/tests/cellarClient.consolidated.test.ts
@@ -86,6 +86,37 @@ describe('fetchConsolidated()', () => {
       .rejects.toThrow(/eurlex_fetch/)
   })
 
+  it('CO6-EN – "no consolidated CELEX" error message is in English', async () => {
+    mockFetch.mockResolvedValueOnce(mockSparqlEmptyResponse())
+
+    const client = new CellarClient()
+    await expect(client.fetchConsolidated('reg', 9999, 9999, 'DEU')).rejects.toThrow(
+      'No consolidated version available for reg/9999/9999. Use eurlex_fetch with the CELEX ID for the original OJ version.',
+    )
+  })
+
+  it('CO-404-EN – "consolidated document not retrievable" error message is in English', async () => {
+    mockFetch
+      .mockResolvedValueOnce(mockSparqlCelexResponse('02024R1689-20240712'))
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+
+    const client = new CellarClient()
+    let caught: unknown
+    try {
+      await client.fetchConsolidated('reg', 2024, 1689, 'DEU')
+    } catch (error) {
+      caught = error
+    }
+
+    expect(caught).toBeInstanceOf(Error)
+    const message = (caught as Error).message
+    expect(message).toBe(
+      'No consolidated version available for reg/2024/1689 (02024R1689-20240712 could not be retrieved). Use eurlex_fetch with the CELEX ID for the original OJ version.',
+    )
+    // No German words should remain
+    expect(message).not.toMatch(/Keine|verfügbar|Verwenden|konsolidierte|Fassung/)
+  })
+
   it('CO6b – maps doc_type to CELEX prefix correctly (R=reg, L=dir, D=dec)', async () => {
     // Test directive
     mockFetch
@@ -133,14 +164,18 @@ describe('fetchConsolidated()', () => {
       .rejects.toThrow(/eurlex_fetch/)
   })
 
-  it('CO-500 – handles non-404 HTTP errors from Cellar REST', async () => {
+  it('CO-500 – handles non-404 HTTP errors from Cellar REST (after exhausting retries)', async () => {
+    // 5xx on the REST step is retryable: 1 initial attempt + 2 retries = 3 total REST calls
     mockFetch
       .mockResolvedValueOnce(mockSparqlCelexResponse('02016R0679-20180525'))
       .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({ ok: false, status: 500 })
 
-    const client = new CellarClient()
+    const client = new CellarClient({ retryDelayFn: async () => {} })
     await expect(client.fetchConsolidated('reg', 2016, 679, 'ENG'))
       .rejects.toThrow(/500/)
+    expect(mockFetch).toHaveBeenCalledTimes(4)
   })
 
   it('CO-DEC – maps dec doc_type to D in CELEX prefix', async () => {

--- a/tests/cellarClient.consolidated.test.ts
+++ b/tests/cellarClient.consolidated.test.ts
@@ -191,3 +191,78 @@ describe('fetchConsolidated()', () => {
     expect(sparqlBody).toContain('02021D0914')
   })
 })
+
+// ===========================================================================
+// findConsolidatedCelex() caching (Task 6)
+// ===========================================================================
+describe('findConsolidatedCelex() caching', () => {
+  it('CACHE-C1 – caches a successful lookup: two identical calls hit fetch once', async () => {
+    mockFetch.mockResolvedValueOnce(mockSparqlCelexResponse('02024R1689-20240712'))
+
+    const client = new CellarClient()
+    const first = await client.findConsolidatedCelex('reg', 2024, 1689)
+    const second = await client.findConsolidatedCelex('reg', 2024, 1689)
+
+    expect(first).toBe('02024R1689-20240712')
+    expect(second).toBe('02024R1689-20240712')
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('CACHE-C2 – caches a legitimate `null` ("not found") result: second call does not hit fetch', async () => {
+    mockFetch.mockResolvedValueOnce(mockSparqlEmptyResponse())
+
+    const client = new CellarClient()
+    const first = await client.findConsolidatedCelex('reg', 9999, 9999)
+    const second = await client.findConsolidatedCelex('reg', 9999, 9999)
+
+    expect(first).toBeNull()
+    expect(second).toBeNull()
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('CACHE-C3 – does NOT cache an error: the second call retries against fetch', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Internal Server Error' })
+      .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Internal Server Error' })
+      .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Internal Server Error' })
+
+    const client = new CellarClient({ retryDelayFn: async () => {} })
+    await expect(client.findConsolidatedCelex('reg', 2024, 1689)).rejects.toThrow(
+      'SPARQL endpoint error: 500',
+    )
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+
+    mockFetch.mockResolvedValueOnce(mockSparqlCelexResponse('02024R1689-20240712'))
+    const second = await client.findConsolidatedCelex('reg', 2024, 1689)
+
+    expect(second).toBe('02024R1689-20240712')
+    expect(mockFetch).toHaveBeenCalledTimes(4)
+  })
+
+  it('CACHE-C4 – a different docType/year/number produces a different cache entry', async () => {
+    mockFetch
+      .mockResolvedValueOnce(mockSparqlCelexResponse('02024R1689-20240712'))
+      .mockResolvedValueOnce(mockSparqlCelexResponse('02016R0679-20160504'))
+
+    const client = new CellarClient()
+    await client.findConsolidatedCelex('reg', 2024, 1689)
+    await client.findConsolidatedCelex('reg', 2016, 679)
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('CACHE-C5 – expires after the injected clock advances past the 6h TTL', async () => {
+    let now = 0
+    mockFetch
+      .mockResolvedValueOnce(mockSparqlCelexResponse('02024R1689-20240712'))
+      .mockResolvedValueOnce(mockSparqlCelexResponse('02024R1689-20240712'))
+
+    const client = new CellarClient({ now: () => now })
+    await client.findConsolidatedCelex('reg', 2024, 1689)
+
+    now += 6 * 60 * 60 * 1000 // exactly 6h later — TTL boundary, must be expired
+    await client.findConsolidatedCelex('reg', 2024, 1689)
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/cellarClient.eurovoc.test.ts
+++ b/tests/cellarClient.eurovoc.test.ts
@@ -71,13 +71,34 @@ describe('resolveEurovocLabel()', () => {
     expect(sparqlSent).not.toContain('work_is_about_concept_eurovoc')
   })
 
-  it('returns null on timeout instead of throwing', async () => {
-    mockFetch.mockRejectedValueOnce(new DOMException('The operation was aborted', 'AbortError'))
+  it('propagates a timeout error instead of silently returning null (no catch-all)', async () => {
+    // AbortError/TimeoutError is retryable; mock it for every attempt so retries
+    // are exhausted (1 initial + 2 retries) and the actionable timeout error surfaces.
+    mockFetch.mockRejectedValue(new DOMException('The operation was aborted', 'AbortError'))
 
-    const client = new CellarClient()
-    const uri = await client.resolveEurovocLabel('something slow')
+    const client = new CellarClient({ retryDelayFn: async () => {} })
+    await expect(client.resolveEurovocLabel('something slow')).rejects.toThrow(
+      /SPARQL query timed out/,
+    )
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+  })
 
-    expect(uri).toBeNull()
+  it('propagates a network error instead of silently returning null (no catch-all)', async () => {
+    mockFetch.mockRejectedValue(new TypeError('fetch failed'))
+
+    const client = new CellarClient({ retryDelayFn: async () => {} })
+    await expect(client.resolveEurovocLabel('something')).rejects.toThrow('fetch failed')
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+  })
+
+  it('propagates a 5xx SPARQL error instead of silently returning null (no catch-all)', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Internal Server Error' })
+
+    const client = new CellarClient({ retryDelayFn: async () => {} })
+    await expect(client.resolveEurovocLabel('something')).rejects.toThrow(
+      'SPARQL endpoint error: 500',
+    )
+    expect(mockFetch).toHaveBeenCalledTimes(3)
   })
 
   it('returns null when no concept matches the label', async () => {

--- a/tests/cellarClient.eurovoc.test.ts
+++ b/tests/cellarClient.eurovoc.test.ts
@@ -226,3 +226,102 @@ describe('buildEurovocQuery() – URI validation', () => {
       .toThrow(/invalid/i)
   })
 })
+
+// ===========================================================================
+// resolveEurovocLabel() caching (Task 6)
+// ===========================================================================
+describe('resolveEurovocLabel() caching', () => {
+  function mockConceptResponse(uri: string) {
+    return {
+      ok: true,
+      json: async () => ({
+        results: { bindings: [{ concept: { type: 'uri', value: uri } }] },
+      }),
+    }
+  }
+
+  function mockEmptyResponse() {
+    return { ok: true, json: async () => ({ results: { bindings: [] } }) }
+  }
+
+  it('CACHE-E1 – caches a successful resolution: two identical calls hit fetch once', async () => {
+    mockFetch.mockResolvedValueOnce(mockConceptResponse('http://eurovoc.europa.eu/4424'))
+
+    const client = new CellarClient()
+    const first = await client.resolveEurovocLabel('artificial intelligence', 'ENG')
+    const second = await client.resolveEurovocLabel('artificial intelligence', 'ENG')
+
+    expect(first).toBe('http://eurovoc.europa.eu/4424')
+    expect(second).toBe('http://eurovoc.europa.eu/4424')
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('CACHE-E2 – cache key is case-insensitive on the label', async () => {
+    mockFetch.mockResolvedValueOnce(mockConceptResponse('http://eurovoc.europa.eu/4424'))
+
+    const client = new CellarClient()
+    await client.resolveEurovocLabel('Artificial Intelligence', 'ENG')
+    await client.resolveEurovocLabel('artificial intelligence', 'ENG')
+    await client.resolveEurovocLabel('ARTIFICIAL INTELLIGENCE', 'ENG')
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('CACHE-E3 – caches a legitimate `null` ("not found") result: second call does not hit fetch', async () => {
+    mockFetch.mockResolvedValueOnce(mockEmptyResponse())
+
+    const client = new CellarClient()
+    const first = await client.resolveEurovocLabel('xyznonexistent', 'DEU')
+    const second = await client.resolveEurovocLabel('xyznonexistent', 'DEU')
+
+    expect(first).toBeNull()
+    expect(second).toBeNull()
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('CACHE-E4 – does NOT cache an error: the second call retries against fetch', async () => {
+    // Persistent rejection so all 3 retry attempts (not just the first) fail.
+    mockFetch.mockRejectedValue(new TypeError('fetch failed'))
+
+    const client = new CellarClient({ retryDelayFn: async () => {} })
+    await expect(client.resolveEurovocLabel('something', 'DEU')).rejects.toThrow('fetch failed')
+    // 1 initial + 2 retries = 3 calls for the first (failed) attempt
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+
+    mockFetch.mockReset()
+    mockFetch.mockResolvedValueOnce(mockConceptResponse('http://eurovoc.europa.eu/9999'))
+    const second = await client.resolveEurovocLabel('something', 'DEU')
+
+    expect(second).toBe('http://eurovoc.europa.eu/9999')
+    // mockReset() above cleared the call count too — a single successful
+    // fetch call here proves the prior error was not served from cache.
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('CACHE-E5 – a different language produces a different cache entry', async () => {
+    mockFetch
+      .mockResolvedValueOnce(mockConceptResponse('http://eurovoc.europa.eu/4424'))
+      .mockResolvedValueOnce(mockConceptResponse('http://eurovoc.europa.eu/5555'))
+
+    const client = new CellarClient()
+    await client.resolveEurovocLabel('protection', 'DEU')
+    await client.resolveEurovocLabel('protection', 'ENG')
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('CACHE-E6 – expires after the injected clock advances past the 24h TTL', async () => {
+    let now = 0
+    mockFetch
+      .mockResolvedValueOnce(mockConceptResponse('http://eurovoc.europa.eu/4424'))
+      .mockResolvedValueOnce(mockConceptResponse('http://eurovoc.europa.eu/4424'))
+
+    const client = new CellarClient({ now: () => now })
+    await client.resolveEurovocLabel('artificial intelligence', 'ENG')
+
+    now += 24 * 60 * 60 * 1000 // exactly 24h later — TTL boundary, must be expired
+    await client.resolveEurovocLabel('artificial intelligence', 'ENG')
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/cellarClient.eurovoc.test.ts
+++ b/tests/cellarClient.eurovoc.test.ts
@@ -55,7 +55,7 @@ describe('resolveEurovocLabel()', () => {
     })
 
     const client = new CellarClient()
-    const uri = await client.resolveEurovocLabel('artificial intelligence')
+    const uri = await client.resolveEurovocLabel('artificial intelligence', 'ENG')
 
     expect(uri).toBe('http://eurovoc.europa.eu/4424')
 
@@ -67,6 +67,8 @@ describe('resolveEurovocLabel()', () => {
     expect(sparqlSent).toContain('LIMIT 1')
     // Must filter to EuroVoc namespace for performance
     expect(sparqlSent).toContain('STRSTARTS(STR(?concept), "http://eurovoc.europa.eu/")')
+    // Must filter the label to the request language
+    expect(sparqlSent).toContain('FILTER(LANG(?label) = "en")')
     // Should NOT contain document-related predicates
     expect(sparqlSent).not.toContain('work_is_about_concept_eurovoc')
   })
@@ -77,7 +79,7 @@ describe('resolveEurovocLabel()', () => {
     mockFetch.mockRejectedValue(new DOMException('The operation was aborted', 'AbortError'))
 
     const client = new CellarClient({ retryDelayFn: async () => {} })
-    await expect(client.resolveEurovocLabel('something slow')).rejects.toThrow(
+    await expect(client.resolveEurovocLabel('something slow', 'DEU')).rejects.toThrow(
       /SPARQL query timed out/,
     )
     expect(mockFetch).toHaveBeenCalledTimes(3)
@@ -87,7 +89,7 @@ describe('resolveEurovocLabel()', () => {
     mockFetch.mockRejectedValue(new TypeError('fetch failed'))
 
     const client = new CellarClient({ retryDelayFn: async () => {} })
-    await expect(client.resolveEurovocLabel('something')).rejects.toThrow('fetch failed')
+    await expect(client.resolveEurovocLabel('something', 'DEU')).rejects.toThrow('fetch failed')
     expect(mockFetch).toHaveBeenCalledTimes(3)
   })
 
@@ -95,7 +97,7 @@ describe('resolveEurovocLabel()', () => {
     mockFetch.mockResolvedValue({ ok: false, status: 500, statusText: 'Internal Server Error' })
 
     const client = new CellarClient({ retryDelayFn: async () => {} })
-    await expect(client.resolveEurovocLabel('something')).rejects.toThrow(
+    await expect(client.resolveEurovocLabel('something', 'DEU')).rejects.toThrow(
       'SPARQL endpoint error: 500',
     )
     expect(mockFetch).toHaveBeenCalledTimes(3)
@@ -108,7 +110,7 @@ describe('resolveEurovocLabel()', () => {
     })
 
     const client = new CellarClient()
-    const uri = await client.resolveEurovocLabel('xyznonexistent123')
+    const uri = await client.resolveEurovocLabel('xyznonexistent123', 'DEU')
 
     expect(uri).toBeNull()
   })
@@ -120,7 +122,7 @@ describe('resolveEurovocLabel()', () => {
     })
 
     const client = new CellarClient()
-    await client.resolveEurovocLabel('data "protection')
+    await client.resolveEurovocLabel('data "protection', 'DEU')
 
     const sparqlSent = mockFetch.mock.calls[0][1].body as string
     expect(sparqlSent).toContain('data \\"protection')

--- a/tests/cellarClient.metadata.test.ts
+++ b/tests/cellarClient.metadata.test.ts
@@ -154,16 +154,18 @@ describe('CellarClient – Metadata', () => {
       )
     })
 
-    it('M8 – throws on SPARQL endpoint error (HTTP 500)', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        statusText: 'Internal Server Error',
-      })
+    it('M8 – throws on SPARQL endpoint error (HTTP 500, after exhausting retries)', async () => {
+      // 5xx is retryable: 1 initial attempt + 2 retries = 3 total calls
+      mockFetch
+        .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Internal Server Error' })
+        .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Internal Server Error' })
+        .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Internal Server Error' })
 
-      await expect(client.metadataQuery('32021R0694', 'DEU')).rejects.toThrow(
+      const retryClient = new CellarClient({ retryDelayFn: async () => {} })
+      await expect(retryClient.metadataQuery('32021R0694', 'DEU')).rejects.toThrow(
         'SPARQL endpoint error: 500'
       )
+      expect(mockFetch).toHaveBeenCalledTimes(3)
     })
 
     it('M8b – correctly parses in_force as boolean', async () => {

--- a/tests/cellarClient.metadata.test.ts
+++ b/tests/cellarClient.metadata.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { CellarClient, escapeSparqlString } from '../src/services/cellarClient.js'
+import { CellarClient } from '../src/services/cellarClient.js'
 
 const mockFetch = vi.fn()
 
@@ -42,13 +42,17 @@ describe('CellarClient – Metadata', () => {
       expect(sparqlEng).toContain('language/ENG')
     })
 
-    it('M5c – query uses GROUP_CONCAT for multi-value fields', () => {
+    it('M5c – query uses GROUP_CONCAT for all four multi-value fields', () => {
       const sparql = client.buildMetadataQuery('32021R0694', 'DEU')
 
-      // Should have GROUP_CONCAT with ||| separator for authors, eurovoc, dirCodes
+      // authors, eurovoc, dirCodes, legalBases
       const groupConcatMatches = sparql.match(/GROUP_CONCAT/g) || []
-      expect(groupConcatMatches.length).toBeGreaterThanOrEqual(3)
+      expect(groupConcatMatches.length).toBeGreaterThanOrEqual(4)
       expect(sparql).toContain('|||')
+      expect(sparql).toContain('AS ?authors')
+      expect(sparql).toContain('AS ?eurovoc')
+      expect(sparql).toContain('AS ?dirCodes')
+      expect(sparql).toContain('AS ?legalBases')
     })
 
     it('M5e – query escapes double-quotes in CELEX ID via escapeSparqlString', () => {
@@ -67,6 +71,46 @@ describe('CellarClient – Metadata', () => {
       expect(sparql).toContain('skos:prefLabel')
       expect(sparql).toContain('PREFIX skos:')
     })
+
+    it('M5f – authors use agent skos:prefLabel, NOT the broken cdm:agent_name', () => {
+      const sparql = client.buildMetadataQuery('32021R0694', 'DEU')
+
+      // The old (bug) property must be gone entirely
+      expect(sparql).not.toContain('agent_name')
+      // Author label = language prefLabel, fallback English, last resort URI tail.
+      expect(sparql).toContain('work_created_by_agent')
+      expect(sparql).toContain('COALESCE')
+    })
+
+    it('M5g – authors label fallback filters by request language then English', () => {
+      const sparqlDeu = client.buildMetadataQuery('32021R0694', 'DEU')
+      // request-language prefLabel filter (de) plus English fallback filter (en)
+      expect(sparqlDeu).toContain('"de"')
+      expect(sparqlDeu).toContain('"en"')
+
+      const sparqlFra = client.buildMetadataQuery('32021R0694', 'FRA')
+      expect(sparqlFra).toContain('"fr"')
+      expect(sparqlFra).toContain('"en"')
+    })
+
+    it('M5h – query includes legal basis via resource_legal_based_on_resource_legal', () => {
+      const sparql = client.buildMetadataQuery('32021R0694', 'DEU')
+
+      expect(sparql).toContain('resource_legal_based_on_resource_legal')
+      // basis CELEX is collected via resource_legal_id_celex on the basis resource
+      expect(sparql).toContain('?basisCelex')
+      expect(sparql).toContain('AS ?legalBases')
+    })
+
+    it('M5i – directory codes combine code tail with skos:prefLabel', () => {
+      const sparql = client.buildMetadataQuery('32021R0694', 'DEU')
+
+      // code tail via REPLACE on the dir-code URI, label combined via CONCAT,
+      // conditional on the label being bound.
+      expect(sparql).toContain('resource_legal_is_about_concept_directory-code')
+      expect(sparql).toContain('CONCAT')
+      expect(sparql).toContain('BOUND(?dirLabel)')
+    })
   })
 
   // =========================================================================
@@ -81,17 +125,30 @@ describe('CellarClient – Metadata', () => {
       }
     }
 
+    // Shaped like the verified live probe result for CELEX 32016R0679 (GDPR),
+    // except date_end_of_validity carries a real (non-sentinel) date here so the
+    // "all fields populated" case is distinct from the dedicated sentinel case.
     const fullBinding = {
-      title: { type: 'literal', value: 'Regulation on carbon border adjustment' },
-      dateDoc: { type: 'literal', value: '2021-05-01' },
-      dateForce: { type: 'literal', value: '2021-10-01' },
+      title: {
+        type: 'literal',
+        value: 'Verordnung (EU) 2016/679 des Europäischen Parlaments und des Rates',
+      },
+      dateDoc: { type: 'literal', value: '2016-04-27' },
+      dateForce: { type: 'literal', value: '2016-05-24' },
       dateEnd: { type: 'literal', value: '2030-12-31' },
-      inForce: { type: 'literal', value: 'true' },
+      inForce: { type: 'literal', value: '1' },
       dateTrans: { type: 'literal', value: '2023-01-01' },
       resType: { type: 'literal', value: 'REG' },
-      authors: { type: 'literal', value: 'European Commission|||Council of the European Union' },
-      eurovoc: { type: 'literal', value: 'climate change|||carbon tax' },
-      dirCodes: { type: 'literal', value: '11.60.30|||15.10.20' },
+      authors: {
+        type: 'literal',
+        value: 'Europäisches Parlament|||Rat der Europäischen Union',
+      },
+      eurovoc: { type: 'literal', value: 'Datenschutz|||persönliche Daten' },
+      dirCodes: {
+        type: 'literal',
+        value: '152020: Unterrichtung, Aufklärung und Vertretung der Verbraucher|||1940: Aktionsprogramme',
+      },
+      legalBases: { type: 'literal', value: '12012E016' },
     }
 
     it('M6 – returns MetadataResult with all fields populated', async () => {
@@ -100,26 +157,75 @@ describe('CellarClient – Metadata', () => {
         json: async () => makeMetadataSparqlResponse(fullBinding),
       })
 
-      const result = await client.metadataQuery('32021R0694', 'DEU')
+      const result = await client.metadataQuery('32016R0679', 'DEU')
 
       expect(result).toMatchObject({
-        celex_id: '32021R0694',
-        title: 'Regulation on carbon border adjustment',
-        date_document: '2021-05-01',
-        date_entry_into_force: '2021-10-01',
+        celex_id: '32016R0679',
+        date_document: '2016-04-27',
+        date_entry_into_force: '2016-05-24',
         date_end_of_validity: '2030-12-31',
         in_force: true,
         date_transposition: '2023-01-01',
         resource_type: 'REG',
-        authors: ['European Commission', 'Council of the European Union'],
-        eurovoc_concepts: ['climate change', 'carbon tax'],
-        directory_codes: ['11.60.30', '15.10.20'],
+        authors: ['Europäisches Parlament', 'Rat der Europäischen Union'],
+        eurovoc_concepts: ['Datenschutz', 'persönliche Daten'],
+        directory_codes: [
+          '152020: Unterrichtung, Aufklärung und Vertretung der Verbraucher',
+          '1940: Aktionsprogramme',
+        ],
+        legal_basis: ['12012E016'],
       })
-      expect(result.eurlex_url).toContain('CELEX:32021R0694')
+      expect(result.eurlex_url).toContain('CELEX:32016R0679')
       expect(result.eurlex_url).toContain('/de/')
     })
 
-    it('M7 – returns empty strings/arrays for missing optional fields', async () => {
+    it('M6b – normalizes the 9999-12-31 end-of-validity sentinel to null', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () =>
+          makeMetadataSparqlResponse({
+            ...fullBinding,
+            dateEnd: { type: 'literal', value: '9999-12-31' },
+          }),
+      })
+
+      const result = await client.metadataQuery('32016R0679', 'DEU')
+      expect(result.date_end_of_validity).toBeNull()
+      // other dates unaffected
+      expect(result.date_document).toBe('2016-04-27')
+      expect(result.date_entry_into_force).toBe('2016-05-24')
+    })
+
+    it('M6c – parses multiple legal bases into an array', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () =>
+          makeMetadataSparqlResponse({
+            ...fullBinding,
+            legalBases: { type: 'literal', value: '12012E016|||12012E114' },
+          }),
+      })
+
+      const result = await client.metadataQuery('32016R0679', 'DEU')
+      expect(result.legal_basis).toEqual(['12012E016', '12012E114'])
+    })
+
+    it('M6d – directory codes preserve combined and label-less entries', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () =>
+          makeMetadataSparqlResponse({
+            ...fullBinding,
+            // one entry with a label, one entry that is a bare code tail (no label)
+            dirCodes: { type: 'literal', value: '152020: Consumer information|||1940' },
+          }),
+      })
+
+      const result = await client.metadataQuery('32016R0679', 'DEU')
+      expect(result.directory_codes).toEqual(['152020: Consumer information', '1940'])
+    })
+
+    it('M7 – returns null dates and empty arrays for missing optional fields', async () => {
       const minimalBinding = {
         title: { type: 'literal', value: 'Minimal document' },
       }
@@ -132,15 +238,16 @@ describe('CellarClient – Metadata', () => {
       const result = await client.metadataQuery('32021R0694', 'DEU')
 
       expect(result.title).toBe('Minimal document')
-      expect(result.date_document).toBe('')
-      expect(result.date_entry_into_force).toBe('')
-      expect(result.date_end_of_validity).toBe('')
+      expect(result.date_document).toBeNull()
+      expect(result.date_entry_into_force).toBeNull()
+      expect(result.date_end_of_validity).toBeNull()
       expect(result.in_force).toBeNull()
-      expect(result.date_transposition).toBe('')
+      expect(result.date_transposition).toBeNull()
       expect(result.resource_type).toBe('')
       expect(result.authors).toEqual([])
       expect(result.eurovoc_concepts).toEqual([])
       expect(result.directory_codes).toEqual([])
+      expect(result.legal_basis).toEqual([])
     })
 
     it('M7b – throws when no bindings returned (CELEX not found)', async () => {
@@ -236,6 +343,7 @@ describe('CellarClient – Metadata', () => {
             authors: { type: 'literal', value: 'Author A|||Author B|||Author C' },
             eurovoc: { type: 'literal', value: 'concept1' },
             dirCodes: { type: 'literal', value: '' },
+            legalBases: { type: 'literal', value: '' },
           }),
       })
 
@@ -244,6 +352,7 @@ describe('CellarClient – Metadata', () => {
       expect(result.authors).toEqual(['Author A', 'Author B', 'Author C'])
       expect(result.eurovoc_concepts).toEqual(['concept1'])
       expect(result.directory_codes).toEqual([])
+      expect(result.legal_basis).toEqual([])
     })
   })
 })

--- a/tests/cellarClient.metadata.test.ts
+++ b/tests/cellarClient.metadata.test.ts
@@ -4,11 +4,17 @@ import { CellarClient } from '../src/services/cellarClient.js'
 const mockFetch = vi.fn()
 
 describe('CellarClient – Metadata', () => {
-  const client = new CellarClient()
+  // Recreated in beforeEach (not a single shared const): metadataQuery() now
+  // caches by celexId|language (Task 6), and several tests below reuse the
+  // same CELEX/language with different mocked responses — a long-lived
+  // client would serve a stale cached result instead of exercising the fetch
+  // mock. A fresh client per test keeps each test's cache empty.
+  let client = new CellarClient()
 
   beforeEach(() => {
     mockFetch.mockReset()
     vi.stubGlobal('fetch', mockFetch)
+    client = new CellarClient()
   })
 
   // =========================================================================
@@ -276,6 +282,11 @@ describe('CellarClient – Metadata', () => {
     })
 
     it('M8b – correctly parses in_force as boolean', async () => {
+      // Each case below queries the *same* celexId/language — metadataQuery()
+      // now caches by that key (Task 6), so a fresh client per case is
+      // required here to actually exercise each mocked response instead of
+      // serving the first one's cached result.
+
       // true case
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -285,7 +296,7 @@ describe('CellarClient – Metadata', () => {
             inForce: { type: 'literal', value: 'true' },
           }),
       })
-      const resultTrue = await client.metadataQuery('32021R0694', 'DEU')
+      const resultTrue = await new CellarClient().metadataQuery('32021R0694', 'DEU')
       expect(resultTrue.in_force).toBe(true)
 
       // false case
@@ -297,7 +308,7 @@ describe('CellarClient – Metadata', () => {
             inForce: { type: 'literal', value: 'false' },
           }),
       })
-      const resultFalse = await client.metadataQuery('32021R0694', 'DEU')
+      const resultFalse = await new CellarClient().metadataQuery('32021R0694', 'DEU')
       expect(resultFalse.in_force).toBe(false)
 
       // "1" case (xsd:boolean alternate)
@@ -309,7 +320,7 @@ describe('CellarClient – Metadata', () => {
             inForce: { type: 'literal', value: '1' },
           }),
       })
-      const result1 = await client.metadataQuery('32021R0694', 'DEU')
+      const result1 = await new CellarClient().metadataQuery('32021R0694', 'DEU')
       expect(result1.in_force).toBe(true)
 
       // "0" case (xsd:boolean alternate)
@@ -321,7 +332,7 @@ describe('CellarClient – Metadata', () => {
             inForce: { type: 'literal', value: '0' },
           }),
       })
-      const result0 = await client.metadataQuery('32021R0694', 'DEU')
+      const result0 = await new CellarClient().metadataQuery('32021R0694', 'DEU')
       expect(result0.in_force).toBe(false)
 
       // missing case
@@ -330,7 +341,7 @@ describe('CellarClient – Metadata', () => {
         ok: true,
         json: async () => makeMetadataSparqlResponse(bindingNoForce),
       })
-      const resultNull = await client.metadataQuery('32021R0694', 'DEU')
+      const resultNull = await new CellarClient().metadataQuery('32021R0694', 'DEU')
       expect(resultNull.in_force).toBeNull()
     })
 
@@ -353,6 +364,78 @@ describe('CellarClient – Metadata', () => {
       expect(result.eurovoc_concepts).toEqual(['concept1'])
       expect(result.directory_codes).toEqual([])
       expect(result.legal_basis).toEqual([])
+    })
+  })
+
+  // =========================================================================
+  // metadataQuery() caching (Task 6)
+  // =========================================================================
+  describe('metadataQuery() caching', () => {
+    function makeMetadataSparqlResponse(binding: Record<string, { type: string; value: string }>) {
+      return { results: { bindings: [binding] } }
+    }
+
+    const minimalBinding = { title: { type: 'literal', value: 'Minimal document' } }
+
+    it('CACHE-M1 – caches a successful result: two identical calls hit fetch once', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => makeMetadataSparqlResponse(minimalBinding),
+      })
+
+      const cachingClient = new CellarClient()
+      const first = await cachingClient.metadataQuery('32021R0694', 'DEU')
+      const second = await cachingClient.metadataQuery('32021R0694', 'DEU')
+
+      expect(first.title).toBe('Minimal document')
+      expect(second.title).toBe('Minimal document')
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('CACHE-M2 – does NOT cache a "not found" error: the second call retries against fetch', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ results: { bindings: [] } }) })
+
+      const cachingClient = new CellarClient()
+      await expect(cachingClient.metadataQuery('39999X0000', 'DEU')).rejects.toThrow(
+        'No metadata found for CELEX: 39999X0000',
+      )
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => makeMetadataSparqlResponse(minimalBinding),
+      })
+      const second = await cachingClient.metadataQuery('39999X0000', 'DEU')
+
+      expect(second.title).toBe('Minimal document')
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('CACHE-M3 – a different language produces a different cache entry', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => makeMetadataSparqlResponse(minimalBinding) })
+        .mockResolvedValueOnce({ ok: true, json: async () => makeMetadataSparqlResponse(minimalBinding) })
+
+      const cachingClient = new CellarClient()
+      await cachingClient.metadataQuery('32021R0694', 'DEU')
+      await cachingClient.metadataQuery('32021R0694', 'ENG')
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('CACHE-M4 – expires after the injected clock advances past the 6h TTL', async () => {
+      let now = 0
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => makeMetadataSparqlResponse(minimalBinding) })
+        .mockResolvedValueOnce({ ok: true, json: async () => makeMetadataSparqlResponse(minimalBinding) })
+
+      const cachingClient = new CellarClient({ now: () => now })
+      await cachingClient.metadataQuery('32021R0694', 'DEU')
+
+      now += 6 * 60 * 60 * 1000 // exactly 6h later — TTL boundary, must be expired
+      await cachingClient.metadataQuery('32021R0694', 'DEU')
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/tests/cellarClient.metadata.test.ts
+++ b/tests/cellarClient.metadata.test.ts
@@ -437,5 +437,21 @@ describe('CellarClient – Metadata', () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(2)
     })
+
+    it('CACHE-M5 – mutating a returned result does not affect a subsequent cache hit', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => makeMetadataSparqlResponse(minimalBinding),
+      })
+
+      const cachingClient = new CellarClient()
+      const first = await cachingClient.metadataQuery('32021R0694', 'DEU')
+      first.title = 'MUTATED'
+
+      const second = await cachingClient.metadataQuery('32021R0694', 'DEU')
+
+      expect(second.title).toBe('Minimal document')
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/tests/cellarClient.retry.test.ts
+++ b/tests/cellarClient.retry.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { CellarClient } from '../src/services/cellarClient.js'
+
+// ---------------------------------------------------------------------------
+// Mock fetch + fake (non-sleeping) retry delay
+// ---------------------------------------------------------------------------
+const mockFetch = vi.fn()
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  vi.stubGlobal('fetch', mockFetch)
+})
+
+/** Builds a client with a fake retryDelayFn so tests never sleep for real. */
+function makeClientWithFakeDelay(): { client: CellarClient; delayFn: ReturnType<typeof vi.fn> } {
+  const delayFn = vi.fn().mockResolvedValue(undefined)
+  const client = new CellarClient({ retryDelayFn: delayFn })
+  return { client, delayFn }
+}
+
+function sparqlOk(bindings: unknown[] = []) {
+  return { ok: true, json: async () => ({ results: { bindings } }) }
+}
+
+function sparql5xx(status = 500) {
+  return { ok: false, status, statusText: 'Internal Server Error' }
+}
+
+function restOk(text = '<html></html>') {
+  return { ok: true, text: async () => text }
+}
+
+function rest5xx(status = 503) {
+  return { ok: false, status, statusText: 'Service Unavailable' }
+}
+
+// ===========================================================================
+// executeSparql retry behaviour (exercised via sparqlQuery)
+// ===========================================================================
+describe('executeSparql() retry', () => {
+  it('retries once on 5xx then succeeds, with injected delay of 500ms', async () => {
+    const { client, delayFn } = makeClientWithFakeDelay()
+    mockFetch.mockResolvedValueOnce(sparql5xx(500)).mockResolvedValueOnce(sparqlOk())
+
+    const { results } = await client.sparqlQuery('test')
+
+    expect(results).toEqual([])
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(delayFn).toHaveBeenCalledTimes(1)
+    expect(delayFn).toHaveBeenCalledWith(500)
+  })
+
+  it('retries with 500ms then 1500ms delays and throws after 3 total attempts (2 retries)', async () => {
+    const { client, delayFn } = makeClientWithFakeDelay()
+    mockFetch
+      .mockResolvedValueOnce(sparql5xx(500))
+      .mockResolvedValueOnce(sparql5xx(500))
+      .mockResolvedValueOnce(sparql5xx(500))
+
+    await expect(client.sparqlQuery('test')).rejects.toThrow('SPARQL endpoint error: 500')
+
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+    expect(delayFn).toHaveBeenNthCalledWith(1, 500)
+    expect(delayFn).toHaveBeenNthCalledWith(2, 1500)
+  })
+
+  it('does not retry on a 4xx SPARQL error', async () => {
+    const { client, delayFn } = makeClientWithFakeDelay()
+    mockFetch.mockResolvedValueOnce(sparql5xx(400))
+
+    await expect(client.sparqlQuery('test')).rejects.toThrow('SPARQL endpoint error: 400')
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(delayFn).not.toHaveBeenCalled()
+  })
+
+  it('retries on network TypeError then succeeds', async () => {
+    const { client, delayFn } = makeClientWithFakeDelay()
+    mockFetch.mockRejectedValueOnce(new TypeError('fetch failed')).mockResolvedValueOnce(sparqlOk())
+
+    const { results } = await client.sparqlQuery('test')
+
+    expect(results).toEqual([])
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(delayFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws an actionable timeout message after exhausting retries on AbortError/TimeoutError', async () => {
+    const { client, delayFn } = makeClientWithFakeDelay()
+    const timeoutError = new DOMException('The operation was aborted due to timeout', 'TimeoutError')
+    mockFetch.mockRejectedValue(timeoutError)
+
+    await expect(client.sparqlQuery('data protection')).rejects.toThrow(
+      /SPARQL query timed out after 30s \(after 2 retries\)\. The Cellar endpoint is slow for broad queries — narrow the search with resource_type, date_from\/date_to, or a more specific query\./,
+    )
+
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+    expect(delayFn).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ===========================================================================
+// fetchCellarDocument retry behaviour (exercised via fetchDocument)
+// ===========================================================================
+describe('fetchDocument() via shared fetchCellarDocument() helper — retry', () => {
+  it('retries once on 5xx then succeeds', async () => {
+    const { client, delayFn } = makeClientWithFakeDelay()
+    mockFetch.mockResolvedValueOnce(rest5xx(503)).mockResolvedValueOnce(restOk('<html>ok</html>'))
+
+    const result = await client.fetchDocument('32021R0694', 'DEU')
+
+    expect(result).toBe('<html>ok</html>')
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(delayFn).toHaveBeenCalledTimes(1)
+    expect(delayFn).toHaveBeenCalledWith(500)
+  })
+
+  it('throws after 3 total attempts (2 retries) on repeated 5xx', async () => {
+    const { client, delayFn } = makeClientWithFakeDelay()
+    mockFetch
+      .mockResolvedValueOnce(rest5xx(503))
+      .mockResolvedValueOnce(rest5xx(503))
+      .mockResolvedValueOnce(rest5xx(503))
+
+    await expect(client.fetchDocument('32021R0694', 'DEU')).rejects.toThrow('Fetch error: 503')
+
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+    expect(delayFn).toHaveBeenNthCalledWith(1, 500)
+    expect(delayFn).toHaveBeenNthCalledWith(2, 1500)
+  })
+
+  it('does NOT retry on 404 (non-retryable)', async () => {
+    const { client, delayFn } = makeClientWithFakeDelay()
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 })
+
+    await expect(client.fetchDocument('00000X0000', 'DEU')).rejects.toThrow('Document not found')
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(delayFn).not.toHaveBeenCalled()
+  })
+
+  it('does NOT retry on 406 (non-retryable)', async () => {
+    const { client, delayFn } = makeClientWithFakeDelay()
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 406 })
+
+    await expect(client.fetchDocument('31995L0046', 'DEU')).rejects.toThrow('not available in XHTML format')
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(delayFn).not.toHaveBeenCalled()
+  })
+
+  it('retries on network TypeError then succeeds', async () => {
+    const { client, delayFn } = makeClientWithFakeDelay()
+    mockFetch
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValueOnce(restOk('<html>ok</html>'))
+
+    const result = await client.fetchDocument('32021R0694', 'DEU')
+
+    expect(result).toBe('<html>ok</html>')
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(delayFn).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ===========================================================================
+// fetchConsolidated() shares the same helper — same retry semantics on the
+// REST step (proves both fetch paths share one implementation)
+// ===========================================================================
+describe('fetchConsolidated() via shared fetchCellarDocument() helper — retry', () => {
+  function sparqlCelex(celex: string) {
+    return { ok: true, json: async () => ({ results: { bindings: [{ celex: { type: 'literal', value: celex } }] } }) }
+  }
+
+  it('retries the REST step once on 5xx then succeeds', async () => {
+    const { client, delayFn } = makeClientWithFakeDelay()
+    mockFetch
+      .mockResolvedValueOnce(sparqlCelex('02024R1689-20240712'))
+      .mockResolvedValueOnce(rest5xx(503))
+      .mockResolvedValueOnce(restOk('<html>consolidated</html>'))
+
+    const result = await client.fetchConsolidated('reg', 2024, 1689, 'DEU')
+
+    expect(result.content).toBe('<html>consolidated</html>')
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+    expect(delayFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT retry the REST step on 404 (non-retryable)', async () => {
+    const { client, delayFn } = makeClientWithFakeDelay()
+    mockFetch.mockResolvedValueOnce(sparqlCelex('02024R1689-20240712')).mockResolvedValueOnce({ ok: false, status: 404 })
+
+    await expect(client.fetchConsolidated('reg', 2024, 1689, 'DEU')).rejects.toThrow(/eurlex_fetch/)
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(delayFn).not.toHaveBeenCalled()
+  })
+})

--- a/tests/cellarClient.task2.test.ts
+++ b/tests/cellarClient.task2.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { CellarClient } from '../src/services/cellarClient.js'
+
+// ---------------------------------------------------------------------------
+// Task 2: SPARQL query fixes
+//   1. search timeout root cause (no ORDER BY, oversampled LIMIT, client sort)
+//   2. L4 filtered-type BIND
+//   3. EuroVoc label precision (language + deterministic order)
+//   4. citations `both` balance (two directional queries + counts)
+//   5. consolidated CELEX anchored-regex matching
+// ---------------------------------------------------------------------------
+
+const mockFetch = vi.fn()
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  vi.stubGlobal('fetch', mockFetch)
+})
+
+function sparqlBody(callIndex: number): string {
+  return mockFetch.mock.calls[callIndex][1].body as string
+}
+
+// ===========================================================================
+// 1. Search timeout root cause
+// ===========================================================================
+describe('buildSparqlQuery() – search timeout fix', () => {
+  const baseParams = {
+    query: 'data protection',
+    resource_type: 'any' as const,
+    language: 'DEU',
+    limit: 10,
+  }
+
+  it('T2-1a – contains no ORDER BY (streaming abort instead of full materialization)', () => {
+    const client = new CellarClient()
+    const sparql = client.buildSparqlQuery(baseParams)
+    expect(sparql).not.toContain('ORDER BY')
+  })
+
+  it('T2-1b – oversamples LIMIT to min(limit*3, 150)', () => {
+    const client = new CellarClient()
+    // limit 10 -> 30
+    expect(client.buildSparqlQuery({ ...baseParams, limit: 10 })).toContain('LIMIT 30')
+    // limit 60 -> capped at 150
+    expect(client.buildSparqlQuery({ ...baseParams, limit: 60 })).toContain('LIMIT 150')
+    // limit 5 -> 15
+    expect(client.buildSparqlQuery({ ...baseParams, limit: 5 })).toContain('LIMIT 15')
+  })
+})
+
+describe('sparqlQuery() – client-side date sort + slice', () => {
+  it('T2-1c – sorts by date desc (empty dates last), dedups, slices to limit', async () => {
+    const body = {
+      results: {
+        bindings: [
+          { work: { value: 'w1' }, celex: { value: 'C1' }, title: { value: 'T1' }, date: { value: '2020-01-01' }, resType: { value: 'REG' } },
+          // no date -> should end up last, then dropped by slice
+          { work: { value: 'w2' }, celex: { value: 'C2' }, title: { value: 'T2' }, resType: { value: 'REG' } },
+          { work: { value: 'w3' }, celex: { value: 'C3' }, title: { value: 'T3' }, date: { value: '2023-05-05' }, resType: { value: 'REG' } },
+          { work: { value: 'w4' }, celex: { value: 'C4' }, title: { value: 'T4' }, date: { value: '2021-07-07' }, resType: { value: 'REG' } },
+        ],
+      },
+    }
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => body })
+
+    const client = new CellarClient()
+    const { results } = await client.sparqlQuery('x', { limit: 3 })
+
+    expect(results.map((r) => r.celex)).toEqual(['C3', 'C4', 'C1'])
+  })
+
+  it('T2-1d – dedup keeps the newest occurrence per CELEX after sorting', async () => {
+    const body = {
+      results: {
+        bindings: [
+          { work: { value: 'w1' }, celex: { value: 'DUP' }, title: { value: 'Old' }, date: { value: '2019-01-01' }, resType: { value: 'DIR' } },
+          { work: { value: 'w2' }, celex: { value: 'DUP' }, title: { value: 'New' }, date: { value: '2024-01-01' }, resType: { value: 'REG' } },
+        ],
+      },
+    }
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => body })
+
+    const client = new CellarClient()
+    const { results } = await client.sparqlQuery('x', { limit: 10 })
+
+    expect(results).toHaveLength(1)
+    expect(results[0].type).toBe('REG') // the 2024 entry wins after date-desc sort
+  })
+})
+
+// ===========================================================================
+// 2. L4 filtered-type BIND
+// ===========================================================================
+describe('buildSparqlQuery() – filtered resource type binding', () => {
+  const baseParams = {
+    query: 'x',
+    resource_type: 'REG' as const,
+    language: 'DEU',
+    limit: 10,
+  }
+
+  it('T2-2a – binds the filtered type directly, not via ?resTypeUri', () => {
+    const client = new CellarClient()
+    const sparql = client.buildSparqlQuery(baseParams)
+
+    expect(sparql).toContain('BIND("REG" AS ?resType)')
+    // The generic URI-extraction binding must not appear when a type is filtered
+    expect(sparql).not.toContain('?resTypeUri')
+  })
+
+  it('T2-2b – uses the generic ?resTypeUri binding for resource_type=any', () => {
+    const client = new CellarClient()
+    const sparql = client.buildSparqlQuery({ ...baseParams, resource_type: 'any' })
+
+    expect(sparql).toContain('?resTypeUri')
+    expect(sparql).toContain('BIND(REPLACE(STR(?resTypeUri)')
+    expect(sparql).not.toContain('BIND("any" AS ?resType)')
+  })
+})
+
+// ===========================================================================
+// 3. EuroVoc label precision
+// ===========================================================================
+describe('resolveEurovocLabel() – language + deterministic order', () => {
+  it('T2-3a – filters label language to the request language lowercase code', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: { bindings: [{ concept: { value: 'http://eurovoc.europa.eu/1' } }] } }),
+    })
+    const client = new CellarClient()
+    await client.resolveEurovocLabel('Datenschutz', 'DEU')
+
+    const body = sparqlBody(0)
+    expect(body).toContain('FILTER(LANG(?label) = "de")')
+  })
+
+  it('T2-3b – orders exact case-insensitive match first, then shortest label', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: { bindings: [{ concept: { value: 'http://eurovoc.europa.eu/1' } }] } }),
+    })
+    const client = new CellarClient()
+    await client.resolveEurovocLabel('data protection', 'ENG')
+
+    const body = sparqlBody(0)
+    expect(body).toContain('ORDER BY DESC(LCASE(STR(?label)) = LCASE("data protection")) STRLEN(STR(?label))')
+    expect(body).toContain('LIMIT 1')
+    // Still namespace-scoped for performance
+    expect(body).toContain('STRSTARTS(STR(?concept), "http://eurovoc.europa.eu/")')
+  })
+})
+
+// ===========================================================================
+// 4. Citations `both` balance
+// ===========================================================================
+describe('citationsQuery() – both-direction split', () => {
+  function citesResponse() {
+    return {
+      ok: true,
+      json: async () => ({
+        results: {
+          bindings: [
+            { celex: { value: '32016R0679' }, title: { value: 'GDPR' }, date: { value: '2016-04-27' }, resType: { value: 'REG' }, rel: { value: 'cites' } },
+            { celex: { value: '31995L0046' }, title: { value: 'DPD' }, date: { value: '1995-10-24' }, resType: { value: 'DIR' }, rel: { value: 'based_on' } },
+          ],
+        },
+      }),
+    }
+  }
+  function citedByResponse() {
+    return {
+      ok: true,
+      json: async () => ({
+        results: {
+          bindings: [
+            { celex: { value: '32023R1234' }, title: { value: 'Later' }, date: { value: '2023-01-01' }, resType: { value: 'REG' }, rel: { value: 'cited_by' } },
+          ],
+        },
+      }),
+    }
+  }
+
+  it('T2-4a – issues two SPARQL calls with split limits (10/10 for limit 20), cites first', async () => {
+    mockFetch.mockResolvedValueOnce(citesResponse()).mockResolvedValueOnce(citedByResponse())
+
+    const client = new CellarClient()
+    const result = await client.citationsQuery('32024R1689', 'DEU', 'both', 20)
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    // cites-side query first, cited_by-side second
+    expect(sparqlBody(0)).toContain('BIND("cites" AS ?rel)')
+    expect(sparqlBody(0)).toContain('LIMIT 10')
+    expect(sparqlBody(1)).toContain('BIND("cited_by" AS ?rel)')
+    expect(sparqlBody(1)).toContain('LIMIT 10')
+
+    // merged: cites-side entries first, then cited_by-side
+    expect(result.citations.map((c) => c.celex)).toEqual(['32016R0679', '31995L0046', '32023R1234'])
+    expect(result.total).toBe(3)
+    expect(result.counts).toEqual({ cites: 2, cited_by: 1 })
+  })
+
+  it('T2-4b – splits an odd limit as ceil/floor', async () => {
+    mockFetch.mockResolvedValueOnce(citesResponse()).mockResolvedValueOnce(citedByResponse())
+
+    const client = new CellarClient()
+    await client.citationsQuery('32024R1689', 'DEU', 'both', 21)
+
+    expect(sparqlBody(0)).toContain('LIMIT 11') // ceil(21/2)
+    expect(sparqlBody(1)).toContain('LIMIT 10') // floor(21/2)
+  })
+
+  it('T2-4c – single-direction cites: one call, counts.cited_by = 0', async () => {
+    mockFetch.mockResolvedValueOnce(citesResponse())
+
+    const client = new CellarClient()
+    const result = await client.citationsQuery('32024R1689', 'DEU', 'cites', 20)
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(result.counts).toEqual({ cites: 2, cited_by: 0 })
+  })
+
+  it('T2-4d – single-direction cited_by: one call, counts.cites = 0', async () => {
+    mockFetch.mockResolvedValueOnce(citedByResponse())
+
+    const client = new CellarClient()
+    const result = await client.citationsQuery('32024R1689', 'DEU', 'cited_by', 20)
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(result.counts).toEqual({ cites: 0, cited_by: 1 })
+  })
+})
+
+// ===========================================================================
+// 5. Consolidated CELEX anchored-regex matching
+// ===========================================================================
+describe('findConsolidatedCelex() – anchored regex', () => {
+  it('T2-5a – uses an anchored REGEX, not a bare STRSTARTS prefix', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: { bindings: [{ celex: { value: '02024R1689-20240712' } }] } }),
+    })
+
+    const client = new CellarClient()
+    await client.findConsolidatedCelex('reg', 2024, 1689)
+
+    const body = sparqlBody(0)
+    expect(body).toContain('REGEX(STR(?celex), "^02024R1689(-[0-9]{8})?$")')
+    expect(body).not.toContain('STRSTARTS')
+    // invariant preserved: newest consolidation is lexicographically largest
+    expect(body).toContain('ORDER BY DESC(?celex)')
+    expect(body).toContain('LIMIT 1')
+  })
+
+  it('T2-5b – zero-pads the number to 4 digits in the regex', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: { bindings: [] } }),
+    })
+
+    const client = new CellarClient()
+    await client.findConsolidatedCelex('reg', 2016, 679)
+
+    expect(sparqlBody(0)).toContain('REGEX(STR(?celex), "^02016R0679(-[0-9]{8})?$")')
+  })
+})

--- a/tests/cellarClient.test.ts
+++ b/tests/cellarClient.test.ts
@@ -406,14 +406,17 @@ describe('fetch timeout', () => {
   })
 
   it('citationsQuery passes AbortSignal to fetch', async () => {
-    mockFetch.mockResolvedValueOnce({
+    // direction 'both' issues two SPARQL POSTs (cites + cited_by) in parallel,
+    // so use a persistent mock that answers every call.
+    mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({ results: { bindings: [] } }),
     })
     const client = new CellarClient()
     await client.citationsQuery('32021R0694', 'DEU', 'both', 10)
-    const callArgs = mockFetch.mock.calls[0]
-    expect(callArgs[1].signal).toBeDefined()
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(mockFetch.mock.calls[0][1].signal).toBeDefined()
+    expect(mockFetch.mock.calls[1][1].signal).toBeDefined()
   })
 
   it('eurovocQuery passes AbortSignal to fetch (URI path)', async () => {

--- a/tests/cellarClient.test.ts
+++ b/tests/cellarClient.test.ts
@@ -73,15 +73,16 @@ describe('sparqlQuery()', () => {
     expect(results).toEqual([])
   })
 
-  it('T3 – throws error on HTTP 500', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 500,
-      statusText: 'Internal Server Error',
-    })
+  it('T3 – throws error on HTTP 500 (after exhausting retries)', async () => {
+    // 5xx is retryable: 1 initial attempt + 2 retries = 3 total calls
+    mockFetch
+      .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Internal Server Error' })
+      .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Internal Server Error' })
+      .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Internal Server Error' })
 
-    const client = new CellarClient()
+    const client = new CellarClient({ retryDelayFn: async () => {} })
     await expect(client.sparqlQuery('test')).rejects.toThrow('SPARQL endpoint error: 500')
+    expect(mockFetch).toHaveBeenCalledTimes(3)
   })
 
   it('T4 – throws error on network failure', async () => {
@@ -270,28 +271,29 @@ describe('buildSparqlQuery() – date_to', () => {
 // Test T14c: fetchDocument non-404 errors
 // ===========================================================================
 describe('fetchDocument() – non-404 errors', () => {
-  it('T14c – throws "Fetch error: 500" on HTTP 500', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 500,
-      statusText: 'Internal Server Error',
-    })
+  it('T14c – throws "Fetch error: 500" on HTTP 500 (after exhausting retries)', async () => {
+    // 5xx is retryable: 1 initial attempt + 2 retries = 3 total calls
+    mockFetch
+      .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Internal Server Error' })
+      .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Internal Server Error' })
+      .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Internal Server Error' })
 
-    const client = new CellarClient()
+    const client = new CellarClient({ retryDelayFn: async () => {} })
     await expect(client.fetchDocument('32021R0694', 'DEU'))
       .rejects.toThrow('Fetch error: 500')
+    expect(mockFetch).toHaveBeenCalledTimes(3)
   })
 
-  it('T14d – throws "Fetch error: 503" on HTTP 503', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 503,
-      statusText: 'Service Unavailable',
-    })
+  it('T14d – throws "Fetch error: 503" on HTTP 503 (after exhausting retries)', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Service Unavailable' })
+      .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Service Unavailable' })
+      .mockResolvedValueOnce({ ok: false, status: 503, statusText: 'Service Unavailable' })
 
-    const client = new CellarClient()
+    const client = new CellarClient({ retryDelayFn: async () => {} })
     await expect(client.fetchDocument('32021R0694', 'DEU'))
       .rejects.toThrow('Fetch error: 503')
+    expect(mockFetch).toHaveBeenCalledTimes(3)
   })
 })
 

--- a/tests/citations.tool.test.ts
+++ b/tests/citations.tool.test.ts
@@ -48,7 +48,7 @@ describe('handleEurlexCitations()', () => {
     })
 
     expect(result.isError).toBeUndefined()
-    expect(result.content[0].text).toContain('Keine Zitierungen gefunden')
+    expect(result.content[0].text).toContain('No citations found')
     expect(result.content[0].text).toContain('99999X9999')
   })
 

--- a/tests/citations.tool.test.ts
+++ b/tests/citations.tool.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const mockCitationsQuery = vi.fn()
+const { mockCitationsQuery } = vi.hoisted(() => ({ mockCitationsQuery: vi.fn() }))
 vi.mock('../src/services/cellarClient.js', () => ({
-  CellarClient: vi.fn().mockImplementation(() => ({
-    citationsQuery: mockCitationsQuery,
-  })),
+  CellarClient: vi.fn(),
+  sharedCellarClient: { citationsQuery: mockCitationsQuery },
 }))
 
 import { handleEurlexCitations } from '../src/tools/citations.js'

--- a/tests/consolidated.tool.test.ts
+++ b/tests/consolidated.tool.test.ts
@@ -226,11 +226,16 @@ describe('handleEurlexConsolidated()', () => {
   })
 
   it('CO10 – returns isError on failure', async () => {
+    // year/number must be within schema bounds so the request actually
+    // reaches CellarClient.fetchConsolidated() and exercises its rejection
+    // (a previously out-of-range year here silently short-circuited on Zod
+    // validation before ever calling the mock, leaving the queued rejection
+    // unconsumed and leaking into whichever test ran next).
     mockFetchConsolidated.mockRejectedValueOnce(new Error('Not found'))
 
     const result = await handleEurlexConsolidated({
       doc_type: 'reg',
-      year: 9999,
+      year: 2024,
       number: 9999,
       language: 'DEU',
       format: 'xhtml',
@@ -239,6 +244,7 @@ describe('handleEurlexConsolidated()', () => {
     })
 
     expect(result.isError).toBe(true)
+    expect(mockFetchConsolidated).toHaveBeenCalledWith('reg', 2024, 9999, 'DEU')
   })
 
   it('CO-SCHEMA – rejects unknown doc_type via Zod schema validation', async () => {
@@ -254,5 +260,127 @@ describe('handleEurlexConsolidated()', () => {
 
     expect(result.isError).toBe(true)
     expect(result.content[0].text).toMatch(/Error:/)
+  })
+})
+
+// ===========================================================================
+// Tests: celex_id input (Task 5) — XOR enforcement + CELEX derivation
+// ===========================================================================
+describe('handleEurlexConsolidated() — celex_id input', () => {
+  it('CO-CX1 – derives doc_type=reg/year/number from a sector-3 "R" CELEX and calls fetchConsolidated with them', async () => {
+    mockFetchConsolidated.mockResolvedValueOnce(
+      mockResult('<p>GDPR</p>', undefined, '02016R0679-20160504'),
+    )
+
+    const result = await handleEurlexConsolidated({
+      celex_id: '32016R0679',
+      language: 'DEU',
+      format: 'xhtml',
+      max_chars: 20000,
+      offset: 0,
+    })
+
+    expect(mockFetchConsolidated).toHaveBeenCalledWith('reg', 2016, 679, 'DEU')
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed.doc_type).toBe('reg')
+    expect(parsed.year).toBe(2016)
+    expect(parsed.number).toBe(679)
+  })
+
+  it('CO-CX2 – derives doc_type=dir from an "L" CELEX', async () => {
+    mockFetchConsolidated.mockResolvedValueOnce(mockResult('<p>NIS2</p>'))
+
+    await handleEurlexConsolidated({
+      celex_id: '32022L2555',
+      language: 'DEU',
+      format: 'xhtml',
+      max_chars: 20000,
+      offset: 0,
+    })
+
+    expect(mockFetchConsolidated).toHaveBeenCalledWith('dir', 2022, 2555, 'DEU')
+  })
+
+  it('CO-CX3 – derives doc_type=dec from a "D" CELEX', async () => {
+    mockFetchConsolidated.mockResolvedValueOnce(mockResult('<p>Decision</p>'))
+
+    await handleEurlexConsolidated({
+      celex_id: '32020D1234',
+      language: 'DEU',
+      format: 'xhtml',
+      max_chars: 20000,
+      offset: 0,
+    })
+
+    expect(mockFetchConsolidated).toHaveBeenCalledWith('dec', 2020, 1234, 'DEU')
+  })
+
+  it('CO-CX4 – rejects a non-sector-3 CELEX with a clear error, without calling fetchConsolidated', async () => {
+    const result = await handleEurlexConsolidated({
+      celex_id: '62018CJ0311',
+      language: 'DEU',
+      format: 'xhtml',
+      max_chars: 20000,
+      offset: 0,
+    })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toMatch(/sector-3/)
+    expect(mockFetchConsolidated).not.toHaveBeenCalled()
+  })
+
+  it('CO-CX5 – rejects a sector-3 CELEX with a type letter outside R/L/D', async () => {
+    const result = await handleEurlexConsolidated({
+      celex_id: '32016X0679',
+      language: 'DEU',
+      format: 'xhtml',
+      max_chars: 20000,
+      offset: 0,
+    })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toMatch(/sector-3/)
+    expect(mockFetchConsolidated).not.toHaveBeenCalled()
+  })
+
+  it('CO-CX6 – rejects when both celex_id and doc_type+year+number are provided', async () => {
+    const result = await handleEurlexConsolidated({
+      celex_id: '32016R0679',
+      doc_type: 'reg',
+      year: 2016,
+      number: 679,
+      language: 'DEU',
+      format: 'xhtml',
+      max_chars: 20000,
+      offset: 0,
+    })
+
+    expect(result.isError).toBe(true)
+    expect(mockFetchConsolidated).not.toHaveBeenCalled()
+  })
+
+  it('CO-CX7 – rejects when neither celex_id nor doc_type+year+number are provided', async () => {
+    const result = await handleEurlexConsolidated({
+      language: 'DEU',
+      format: 'xhtml',
+      max_chars: 20000,
+      offset: 0,
+    })
+
+    expect(result.isError).toBe(true)
+    expect(mockFetchConsolidated).not.toHaveBeenCalled()
+  })
+
+  it('CO-CX8 – rejects a partial triple (doc_type only, no celex_id)', async () => {
+    const result = await handleEurlexConsolidated({
+      doc_type: 'reg',
+      language: 'DEU',
+      format: 'xhtml',
+      max_chars: 20000,
+      offset: 0,
+    })
+
+    expect(result.isError).toBe(true)
+    expect(mockFetchConsolidated).not.toHaveBeenCalled()
   })
 })

--- a/tests/consolidated.tool.test.ts
+++ b/tests/consolidated.tool.test.ts
@@ -14,8 +14,11 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
-const mockResult = (content: string, eliUrl = 'http://data.europa.eu/eli/reg/2024/1689/deu/xhtml') =>
-  ({ content, eliUrl })
+const mockResult = (
+  content: string,
+  eliUrl = 'http://data.europa.eu/eli/reg/2024/1689/deu/xhtml',
+  consolidatedCelex = '02024R1689-20240712',
+) => ({ content, eliUrl, consolidatedCelex })
 
 describe('handleEurlexConsolidated()', () => {
   it('CO7 – returns document content with truncation info', async () => {
@@ -28,6 +31,7 @@ describe('handleEurlexConsolidated()', () => {
       language: 'DEU',
       format: 'xhtml',
       max_chars: 20000,
+      offset: 0,
     })
 
     const parsed = JSON.parse(result.content[0].text)
@@ -49,6 +53,7 @@ describe('handleEurlexConsolidated()', () => {
       language: 'DEU',
       format: 'plain',
       max_chars: 20000,
+      offset: 0,
     })
     const parsed = JSON.parse(result.content[0].text)
     expect(parsed.content).not.toContain('alert')
@@ -66,6 +71,7 @@ describe('handleEurlexConsolidated()', () => {
       language: 'DEU',
       format: 'plain',
       max_chars: 20000,
+      offset: 0,
     })
 
     const parsed = JSON.parse(result.content[0].text)
@@ -73,7 +79,7 @@ describe('handleEurlexConsolidated()', () => {
     expect(parsed.content).toContain('Text')
   })
 
-  it('CO9b – char_count reports original length when truncated', async () => {
+  it('CO9b – total_chars reports original length when truncated', async () => {
     mockFetchConsolidated.mockResolvedValueOnce(mockResult('x'.repeat(5000)))
     const result = await handleEurlexConsolidated({
       doc_type: 'reg',
@@ -82,10 +88,13 @@ describe('handleEurlexConsolidated()', () => {
       language: 'DEU',
       format: 'xhtml',
       max_chars: 1000,
+      offset: 0,
     })
     const parsed = JSON.parse(result.content[0].text)
     expect(parsed.truncated).toBe(true)
-    expect(parsed.char_count).toBe(5000)
+    expect(parsed.total_chars).toBe(5000)
+    expect(parsed.returned_chars).toBe(1000)
+    expect(parsed.next_offset).toBe(1000)
   })
 
   it('CO9 – truncates at max_chars', async () => {
@@ -98,11 +107,76 @@ describe('handleEurlexConsolidated()', () => {
       language: 'DEU',
       format: 'xhtml',
       max_chars: 5000,
+      offset: 0,
     })
 
     const parsed = JSON.parse(result.content[0].text)
     expect(parsed.truncated).toBe(true)
-    expect(parsed.char_count).toBe(30000)
+    expect(parsed.total_chars).toBe(30000)
+  })
+
+  it('CO11 – offset paginates into the middle of the document', async () => {
+    // Schema requires max_chars >= 1000, so use a document long enough to
+    // exercise a genuine middle window.
+    const doc = '0123456789'.repeat(300) // 3000 chars
+    mockFetchConsolidated.mockResolvedValueOnce(mockResult(doc))
+
+    const result = await handleEurlexConsolidated({
+      doc_type: 'reg',
+      year: 2024,
+      number: 1689,
+      language: 'DEU',
+      format: 'xhtml',
+      max_chars: 1000,
+      offset: 1000,
+    })
+
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed.content).toBe(doc.slice(1000, 2000))
+    expect(parsed.offset).toBe(1000)
+    expect(parsed.returned_chars).toBe(1000)
+    expect(parsed.truncated).toBe(true)
+    expect(parsed.next_offset).toBe(2000)
+  })
+
+  it('CO12 – consolidated_celex and consolidation_date are derived from the resolved CELEX (with -YYYYMMDD suffix)', async () => {
+    mockFetchConsolidated.mockResolvedValueOnce(
+      mockResult('<p>Content</p>', undefined, '02016R0679-20160504'),
+    )
+
+    const result = await handleEurlexConsolidated({
+      doc_type: 'reg',
+      year: 2016,
+      number: 679,
+      language: 'DEU',
+      format: 'xhtml',
+      max_chars: 20000,
+      offset: 0,
+    })
+
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed.consolidated_celex).toBe('02016R0679-20160504')
+    expect(parsed.consolidation_date).toBe('2016-05-04')
+  })
+
+  it('CO13 – consolidation_date is null when the resolved CELEX has no -YYYYMMDD suffix', async () => {
+    mockFetchConsolidated.mockResolvedValueOnce(
+      mockResult('<p>Content</p>', undefined, '02016R0679'),
+    )
+
+    const result = await handleEurlexConsolidated({
+      doc_type: 'reg',
+      year: 2016,
+      number: 679,
+      language: 'DEU',
+      format: 'xhtml',
+      max_chars: 20000,
+      offset: 0,
+    })
+
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed.consolidated_celex).toBe('02016R0679')
+    expect(parsed.consolidation_date).toBeNull()
   })
 
   it('CO-TYPE – result satisfies ConsolidatedResult shape', async () => {
@@ -115,23 +189,40 @@ describe('handleEurlexConsolidated()', () => {
       language: 'DEU',
       format: 'xhtml',
       max_chars: 20000,
+      offset: 0,
     })
 
     const parsed: ConsolidatedResult = JSON.parse(result.content[0].text)
     const requiredKeys: (keyof ConsolidatedResult)[] = [
-      'doc_type', 'year', 'number', 'language', 'content', 'truncated', 'char_count', 'eli_url',
+      'doc_type',
+      'year',
+      'number',
+      'language',
+      'content',
+      'truncated',
+      'returned_chars',
+      'total_chars',
+      'offset',
+      'next_offset',
+      'eli_url',
+      'consolidated_celex',
+      'consolidation_date',
     ]
     for (const key of requiredKeys) {
       expect(parsed).toHaveProperty(key)
     }
+    expect(parsed).not.toHaveProperty('char_count')
     expect(typeof parsed.doc_type).toBe('string')
     expect(typeof parsed.year).toBe('number')
     expect(typeof parsed.number).toBe('number')
     expect(typeof parsed.language).toBe('string')
     expect(typeof parsed.content).toBe('string')
     expect(typeof parsed.truncated).toBe('boolean')
-    expect(typeof parsed.char_count).toBe('number')
+    expect(typeof parsed.returned_chars).toBe('number')
+    expect(typeof parsed.total_chars).toBe('number')
+    expect(typeof parsed.offset).toBe('number')
     expect(typeof parsed.eli_url).toBe('string')
+    expect(typeof parsed.consolidated_celex).toBe('string')
   })
 
   it('CO10 – returns isError on failure', async () => {
@@ -144,6 +235,7 @@ describe('handleEurlexConsolidated()', () => {
       language: 'DEU',
       format: 'xhtml',
       max_chars: 20000,
+      offset: 0,
     })
 
     expect(result.isError).toBe(true)
@@ -157,6 +249,7 @@ describe('handleEurlexConsolidated()', () => {
       language: 'DEU',
       format: 'xhtml',
       max_chars: 20000,
+      offset: 0,
     })
 
     expect(result.isError).toBe(true)

--- a/tests/consolidated.tool.test.ts
+++ b/tests/consolidated.tool.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const mockFetchConsolidated = vi.fn()
+const { mockFetchConsolidated } = vi.hoisted(() => ({ mockFetchConsolidated: vi.fn() }))
 vi.mock('../src/services/cellarClient.js', () => ({
-  CellarClient: vi.fn().mockImplementation(() => ({
-    fetchConsolidated: mockFetchConsolidated,
-  })),
+  CellarClient: vi.fn(),
+  sharedCellarClient: { fetchConsolidated: mockFetchConsolidated },
 }))
 
 import { handleEurlexConsolidated } from '../src/tools/consolidated.js'

--- a/tests/consolidatedSchema.test.ts
+++ b/tests/consolidatedSchema.test.ts
@@ -36,4 +36,20 @@ describe('consolidatedSchema', () => {
   it('rejects unknown format', () => {
     expect(() => consolidatedSchema.parse({ doc_type: 'reg', year: 2024, number: 1, format: 'pdf' })).toThrow()
   })
+
+  it('offset defaults to 0', () => {
+    const result = consolidatedSchema.parse({ doc_type: 'reg', year: 2024, number: 1689 })
+    expect(result.offset).toBe(0)
+  })
+
+  it('accepts an explicit non-negative offset', () => {
+    const result = consolidatedSchema.parse({ doc_type: 'reg', year: 2024, number: 1689, offset: 5000 })
+    expect(result.offset).toBe(5000)
+  })
+
+  it('rejects a negative offset', () => {
+    expect(() =>
+      consolidatedSchema.parse({ doc_type: 'reg', year: 2024, number: 1689, offset: -1 }),
+    ).toThrow()
+  })
 })

--- a/tests/consolidatedSchema.test.ts
+++ b/tests/consolidatedSchema.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { consolidatedSchema } from '../src/schemas/consolidatedSchema.js'
+import { consolidatedSchema, consolidatedInputSchema } from '../src/schemas/consolidatedSchema.js'
 
 describe('consolidatedSchema', () => {
   it('CO1 – accepts type/year/number with defaults', () => {
@@ -57,5 +57,71 @@ describe('consolidatedSchema', () => {
     expect(() =>
       consolidatedSchema.parse({ doc_type: 'reg', year: 2024, number: 1689, offset: 1.5 }),
     ).toThrow()
+  })
+
+  // -------------------------------------------------------------------------
+  // celex_id input (base schema, per-field validation only — the "exactly
+  // one input form" invariant is NOT enforced here, only in
+  // consolidatedInputSchema below; server.tool(consolidatedSchema.shape) only
+  // ever sees this per-field shape).
+  // -------------------------------------------------------------------------
+  it('CO-CX1 – accepts celex_id alone, doc_type/year/number stay undefined', () => {
+    const result = consolidatedSchema.parse({ celex_id: '32016R0679' })
+    expect(result.celex_id).toBe('32016R0679')
+    expect(result.doc_type).toBeUndefined()
+    expect(result.year).toBeUndefined()
+    expect(result.number).toBeUndefined()
+  })
+
+  it('CO-CX2 – rejects a celex_id with disallowed characters', () => {
+    expect(() => consolidatedSchema.parse({ celex_id: '<script>' })).toThrow()
+  })
+
+  it('CO-CX3 – doc_type/year/number are optional at the per-field level (no XOR check here)', () => {
+    expect(() => consolidatedSchema.parse({})).not.toThrow()
+  })
+})
+
+// ===========================================================================
+// consolidatedInputSchema — celex_id XOR doc_type+year+number (Task 5)
+// ===========================================================================
+describe('consolidatedInputSchema (celex_id XOR doc_type+year+number)', () => {
+  it('CO-XOR1 – accepts celex_id alone', () => {
+    const result = consolidatedInputSchema.parse({ celex_id: '32016R0679' })
+    expect(result.celex_id).toBe('32016R0679')
+  })
+
+  it('CO-XOR2 – accepts doc_type+year+number alone', () => {
+    const result = consolidatedInputSchema.parse({ doc_type: 'reg', year: 2016, number: 679 })
+    expect(result.doc_type).toBe('reg')
+    expect(result.year).toBe(2016)
+    expect(result.number).toBe(679)
+  })
+
+  it('CO-XOR3 – rejects celex_id and doc_type+year+number provided together', () => {
+    expect(() =>
+      consolidatedInputSchema.parse({
+        celex_id: '32016R0679',
+        doc_type: 'reg',
+        year: 2016,
+        number: 679,
+      }),
+    ).toThrow()
+  })
+
+  it('CO-XOR4 – rejects neither celex_id nor doc_type+year+number provided', () => {
+    expect(() => consolidatedInputSchema.parse({})).toThrow()
+  })
+
+  it('CO-XOR5 – rejects a partial triple (doc_type only) when celex_id is absent', () => {
+    expect(() => consolidatedInputSchema.parse({ doc_type: 'reg' })).toThrow()
+  })
+
+  it('CO-XOR6 – rejects a partial triple (year+number, no doc_type) when celex_id is absent', () => {
+    expect(() => consolidatedInputSchema.parse({ year: 2016, number: 679 })).toThrow()
+  })
+
+  it('CO-XOR7 – rejects celex_id mixed with a single triple field', () => {
+    expect(() => consolidatedInputSchema.parse({ celex_id: '32016R0679', year: 2016 })).toThrow()
   })
 })

--- a/tests/consolidatedSchema.test.ts
+++ b/tests/consolidatedSchema.test.ts
@@ -52,4 +52,10 @@ describe('consolidatedSchema', () => {
       consolidatedSchema.parse({ doc_type: 'reg', year: 2024, number: 1689, offset: -1 }),
     ).toThrow()
   })
+
+  it('rejects a non-integer offset', () => {
+    expect(() =>
+      consolidatedSchema.parse({ doc_type: 'reg', year: 2024, number: 1689, offset: 1.5 }),
+    ).toThrow()
+  })
 })

--- a/tests/eurovoc.tool.test.ts
+++ b/tests/eurovoc.tool.test.ts
@@ -41,7 +41,7 @@ describe('handleEurlexByEurovoc()', () => {
       limit: 10,
     })
 
-    expect(result.content[0].text).toContain('Keine Ergebnisse')
+    expect(result.content[0].text).toContain('No results')
   })
 
   it('E11 – returns isError on failure', async () => {

--- a/tests/eurovoc.tool.test.ts
+++ b/tests/eurovoc.tool.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const mockEurovocQuery = vi.fn()
+const { mockEurovocQuery } = vi.hoisted(() => ({ mockEurovocQuery: vi.fn() }))
 vi.mock('../src/services/cellarClient.js', () => ({
-  CellarClient: vi.fn().mockImplementation(() => ({
-    eurovocQuery: mockEurovocQuery,
-  })),
+  CellarClient: vi.fn(),
+  sharedCellarClient: { eurovocQuery: mockEurovocQuery },
 }))
 
 import { handleEurlexByEurovoc } from '../src/tools/eurovoc.js'

--- a/tests/eval/phase1-foundation.eval.test.ts
+++ b/tests/eval/phase1-foundation.eval.test.ts
@@ -134,7 +134,10 @@ describe('Phase 1 Eval – Foundation', () => {
         language: 'DEU',
         content: 'content',
         truncated: false,
-        char_count: 7,
+        returned_chars: 7,
+        total_chars: 7,
+        offset: 0,
+        next_offset: null,
         source_url: 'https://example.com',
       }
       expect(result.celex_id).toBe('32020R0001')

--- a/tests/eval/phase2-cellar-client.eval.test.ts
+++ b/tests/eval/phase2-cellar-client.eval.test.ts
@@ -76,7 +76,7 @@ describe('Phase 2 Eval – CellarClient', () => {
 
     it('contains LIMIT', () => {
       const sparql = client.buildSparqlQuery(baseParams)
-      expect(sparql).toContain('LIMIT 10')
+      expect(sparql).toContain('LIMIT 30')
     })
 
     it('with resource_type=REG contains resource-type/REG', () => {

--- a/tests/eval/phase3-tools-prompt.eval.test.ts
+++ b/tests/eval/phase3-tools-prompt.eval.test.ts
@@ -158,7 +158,7 @@ describe('Phase 3 Eval – Tools + Prompt', () => {
   // eurlex_guide prompt content
   // -------------------------------------------------------------------------
   describe('eurlex_guide prompt content', () => {
-    it('contains key sections: CELEX, Suchstrategie, 32024R1689', async () => {
+    it('contains key sections: CELEX, Search strategy, 32024R1689', async () => {
       // Use a mock server to capture the prompt content
       let capturedCallback: (() => any) | undefined
 
@@ -177,7 +177,7 @@ describe('Phase 3 Eval – Tools + Prompt', () => {
       const text = result.messages[0].content.text
 
       expect(text).toContain('CELEX')
-      expect(text).toContain('Suchstrategie')
+      expect(text).toContain('Search strategy')
       expect(text).toContain('32024R1689')
     })
   })

--- a/tests/eval/phase4-server.eval.test.ts
+++ b/tests/eval/phase4-server.eval.test.ts
@@ -107,7 +107,7 @@ describe('Phase 4 Eval – Server', () => {
 
     const text = result.messages[0].content as { type: string; text: string }
     expect(text.text).toContain('CELEX')
-    expect(text.text).toContain('Suchstrategie')
+    expect(text.text).toContain('Search strategy')
     expect(text.text).toContain('32024R1689')
   })
 })

--- a/tests/eval/phase4-server.eval.test.ts
+++ b/tests/eval/phase4-server.eval.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
-import { createServer } from '../../src/index.js'
+import { createServer } from '../../src/server.js'
 
 // ---------------------------------------------------------------------------
 // Helper: spin up a server + client pair over in-memory transport

--- a/tests/eval/phase5-validation.eval.test.ts
+++ b/tests/eval/phase5-validation.eval.test.ts
@@ -12,7 +12,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
-import { createServer } from '../../src/index.js'
+import { createServer } from '../../src/server.js'
 import { CellarClient, escapeSparqlString } from '../../src/services/cellarClient.js'
 import { SPARQL_ENDPOINT, CELLAR_REST_BASE } from '../../src/constants.js'
 

--- a/tests/fetch.tool.test.ts
+++ b/tests/fetch.tool.test.ts
@@ -82,20 +82,11 @@ describe('handleEurlexFetch()', () => {
     expect(result.content[0].text).toContain('Document not found')
   })
 
-  it('T19b – returns isError: true when schema validation fails (invalid CELEX-ID)', async () => {
-    const result = await handleEurlexFetch({
-      celex_id: 'INVALID!!!',
-      language: 'DEU',
-      format: 'xhtml',
-      max_chars: 20000,
-      offset: 0,
-    })
-
-    expect(result.isError).toBe(true)
-    expect(result.content).toHaveLength(1)
-    expect(result.content[0].type).toBe('text')
-    expect(result.content[0].text).toMatch(/Error:/)
-  })
+  // Note: handleEurlexFetch no longer validates celex_id format itself — the
+  // SDK validates via fetchSchema.shape before the handler ever runs (see
+  // registerFetchTool). That regex behavior is covered at the schema level in
+  // fetchSchema.test.ts (F3, F4); a redundant handler-level "invalid CELEX"
+  // test was removed here since it no longer exercises real validation logic.
 
   it('T18c – total_chars reports original length when truncated', async () => {
     const longContent = 'x'.repeat(5000)

--- a/tests/fetch.tool.test.ts
+++ b/tests/fetch.tool.test.ts
@@ -3,12 +3,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // ---------------------------------------------------------------------------
 // Mock CellarClient — must be before importing the tool handler
 // ---------------------------------------------------------------------------
-const mockFetchDocument = vi.fn()
+const { mockFetchDocument } = vi.hoisted(() => ({ mockFetchDocument: vi.fn() }))
 
 vi.mock('../src/services/cellarClient.js', () => ({
-  CellarClient: vi.fn().mockImplementation(() => ({
-    fetchDocument: mockFetchDocument,
-  })),
+  CellarClient: vi.fn(),
+  sharedCellarClient: { fetchDocument: mockFetchDocument },
 }))
 
 import { CELLAR_REST_BASE } from '../src/constants.js'

--- a/tests/fetch.tool.test.ts
+++ b/tests/fetch.tool.test.ts
@@ -11,6 +11,7 @@ vi.mock('../src/services/cellarClient.js', () => ({
   })),
 }))
 
+import { CELLAR_REST_BASE } from '../src/constants.js'
 import { handleEurlexFetch } from '../src/tools/fetch.js'
 import type { FetchResult } from '../src/types.js'
 
@@ -33,6 +34,7 @@ describe('handleEurlexFetch()', () => {
       language: 'DEU',
       format: 'xhtml',
       max_chars: 20000,
+      offset: 0,
     })
 
     expect(result.content).toHaveLength(1)
@@ -52,6 +54,7 @@ describe('handleEurlexFetch()', () => {
       language: 'DEU',
       format: 'xhtml',
       max_chars: 20000,
+      offset: 0,
     })
 
     expect(result.content).toHaveLength(1)
@@ -70,6 +73,7 @@ describe('handleEurlexFetch()', () => {
       language: 'DEU',
       format: 'xhtml',
       max_chars: 20000,
+      offset: 0,
     })
 
     expect(result.isError).toBe(true)
@@ -84,6 +88,7 @@ describe('handleEurlexFetch()', () => {
       language: 'DEU',
       format: 'xhtml',
       max_chars: 20000,
+      offset: 0,
     })
 
     expect(result.isError).toBe(true)
@@ -92,7 +97,7 @@ describe('handleEurlexFetch()', () => {
     expect(result.content[0].text).toMatch(/Error:/)
   })
 
-  it('T18c – char_count reports original length when truncated', async () => {
+  it('T18c – total_chars reports original length when truncated', async () => {
     const longContent = 'x'.repeat(5000)
     mockFetchDocument.mockResolvedValueOnce(longContent)
     const result = await handleEurlexFetch({
@@ -100,10 +105,13 @@ describe('handleEurlexFetch()', () => {
       language: 'DEU',
       format: 'xhtml',
       max_chars: 1000,
+      offset: 0,
     })
     const parsed = JSON.parse(result.content[0].text)
     expect(parsed.truncated).toBe(true)
-    expect(parsed.char_count).toBe(5000)
+    expect(parsed.total_chars).toBe(5000)
+    expect(parsed.returned_chars).toBe(1000)
+    expect(parsed.next_offset).toBe(1000)
   })
 
   it('T20b – plain format strips script and style tags completely', async () => {
@@ -115,6 +123,7 @@ describe('handleEurlexFetch()', () => {
       language: 'DEU',
       format: 'plain',
       max_chars: 20000,
+      offset: 0,
     })
     const parsed = JSON.parse(result.content[0].text)
     expect(parsed.content).not.toContain('alert')
@@ -132,6 +141,7 @@ describe('handleEurlexFetch()', () => {
       language: 'DEU',
       format: 'plain',
       max_chars: 20000,
+      offset: 0,
     })
 
     expect(result.content).toHaveLength(1)
@@ -142,6 +152,71 @@ describe('handleEurlexFetch()', () => {
     expect(parsed.content).toContain('Artikel 1')
   })
 
+  it('T21 – offset paginates into the middle of the document', async () => {
+    // Schema requires max_chars >= 1000, so use a document long enough to
+    // exercise a genuine middle window.
+    const doc = '0123456789'.repeat(300) // 3000 chars
+    mockFetchDocument.mockResolvedValueOnce(doc)
+
+    const result = await handleEurlexFetch({
+      celex_id: '32024R1689',
+      language: 'DEU',
+      format: 'xhtml',
+      max_chars: 1000,
+      offset: 1000,
+    })
+
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed.content).toBe(doc.slice(1000, 2000))
+    expect(parsed.offset).toBe(1000)
+    expect(parsed.returned_chars).toBe(1000)
+    expect(parsed.total_chars).toBe(3000)
+    expect(parsed.truncated).toBe(true)
+    expect(parsed.next_offset).toBe(2000)
+  })
+
+  it('T22 – offset 0 then offset next_offset concatenate to the full processed text', async () => {
+    const full = 'The quick brown fox jumps over the lazy dog. '.repeat(60) // ~2760 chars
+    mockFetchDocument.mockResolvedValueOnce(full).mockResolvedValueOnce(full)
+
+    const first = await handleEurlexFetch({
+      celex_id: '32024R1689',
+      language: 'DEU',
+      format: 'xhtml',
+      max_chars: 1000,
+      offset: 0,
+    })
+    const firstParsed = JSON.parse(first.content[0].text)
+    expect(firstParsed.truncated).toBe(true)
+
+    const second = await handleEurlexFetch({
+      celex_id: '32024R1689',
+      language: 'DEU',
+      format: 'xhtml',
+      max_chars: 20000,
+      offset: firstParsed.next_offset,
+    })
+    const secondParsed = JSON.parse(second.content[0].text)
+    expect(secondParsed.next_offset).toBeNull()
+
+    expect(firstParsed.content + secondParsed.content).toBe(full)
+  })
+
+  it('T23 – source_url is built from the CELLAR_REST_BASE constant', async () => {
+    mockFetchDocument.mockResolvedValueOnce('<p>Content</p>')
+
+    const result = await handleEurlexFetch({
+      celex_id: '32024R1689',
+      language: 'DEU',
+      format: 'xhtml',
+      max_chars: 20000,
+      offset: 0,
+    })
+
+    const parsed = JSON.parse(result.content[0].text)
+    expect(parsed.source_url).toBe(`${CELLAR_REST_BASE}/32024R1689`)
+  })
+
   it('T-TYPE – fetch output matches FetchResult interface fields', async () => {
     mockFetchDocument.mockResolvedValueOnce('<div><p>Content</p></div>')
 
@@ -150,14 +225,24 @@ describe('handleEurlexFetch()', () => {
       language: 'DEU',
       format: 'xhtml',
       max_chars: 20000,
+      offset: 0,
     })
 
     const parsed: FetchResult = JSON.parse(result.content[0].text)
     const requiredKeys: (keyof FetchResult)[] = [
-      'celex_id', 'language', 'content', 'truncated', 'char_count', 'source_url',
+      'celex_id',
+      'language',
+      'content',
+      'truncated',
+      'returned_chars',
+      'total_chars',
+      'offset',
+      'next_offset',
+      'source_url',
     ]
     for (const key of requiredKeys) {
       expect(parsed).toHaveProperty(key)
     }
+    expect(parsed).not.toHaveProperty('char_count')
   })
 })

--- a/tests/fetchSchema.test.ts
+++ b/tests/fetchSchema.test.ts
@@ -22,4 +22,22 @@ describe('fetchSchema', () => {
     expect(() => fetchSchema.parse({ celex_id: '' })).toThrow(ZodError)
     expect(() => fetchSchema.parse({ celex_id: '3AB' })).toThrow(ZodError)
   })
+
+  it('F5 – offset defaults to 0', () => {
+    const result = fetchSchema.parse({ celex_id: '32024R1689' })
+    expect(result.offset).toBe(0)
+  })
+
+  it('F6 – accepts an explicit non-negative offset', () => {
+    const result = fetchSchema.parse({ celex_id: '32024R1689', offset: 20000 })
+    expect(result.offset).toBe(20000)
+  })
+
+  it('F7 – rejects a negative offset', () => {
+    expect(() => fetchSchema.parse({ celex_id: '32024R1689', offset: -1 })).toThrow(ZodError)
+  })
+
+  it('F8 – rejects a non-integer offset', () => {
+    expect(() => fetchSchema.parse({ celex_id: '32024R1689', offset: 1.5 })).toThrow(ZodError)
+  })
 })

--- a/tests/http-transport.test.ts
+++ b/tests/http-transport.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, afterEach } from 'vitest'
+import { describe, test, expect, afterEach, beforeEach, vi } from 'vitest'
 import http from 'node:http'
 import { createApp } from '../src/http.js'
 
@@ -204,5 +204,195 @@ describe('HTTP transport', () => {
     expect(res.status).toBe(400)
     const body = await res.json()
     expect(body.error).toMatch(/session/i)
+  })
+
+  // --- DNS rebinding protection (MCP_ALLOWED_HOSTS / MCP_ALLOWED_ORIGINS) ---
+
+  describe('DNS rebinding protection', () => {
+    let originalAllowedHosts: string | undefined
+    let originalAllowedOrigins: string | undefined
+    let warnSpy: ReturnType<typeof vi.spyOn> | undefined
+
+    beforeEach(() => {
+      originalAllowedHosts = process.env.MCP_ALLOWED_HOSTS
+      originalAllowedOrigins = process.env.MCP_ALLOWED_ORIGINS
+      delete process.env.MCP_ALLOWED_HOSTS
+      delete process.env.MCP_ALLOWED_ORIGINS
+    })
+
+    afterEach(() => {
+      if (originalAllowedHosts === undefined) delete process.env.MCP_ALLOWED_HOSTS
+      else process.env.MCP_ALLOWED_HOSTS = originalAllowedHosts
+      if (originalAllowedOrigins === undefined) delete process.env.MCP_ALLOWED_ORIGINS
+      else process.env.MCP_ALLOWED_ORIGINS = originalAllowedOrigins
+      warnSpy?.mockRestore()
+      warnSpy = undefined
+    })
+
+    /**
+     * Discovers a free port first, then builds the app with MCP_ALLOWED_HOSTS derived
+     * from that port — needed because the allowed host list must match the real
+     * host:port the test server ends up listening on.
+     */
+    function startServerWithAllowedHost(computeAllowedHosts: (port: number) => string) {
+      return new Promise<{ baseUrl: string; close: () => Promise<void> }>((resolve) => {
+        let handler: ReturnType<typeof createApp>['app'] | undefined
+        const server = http.createServer((req, res) => handler!(req, res))
+        server.listen(0, () => {
+          const addr = server.address() as { port: number }
+          process.env.MCP_ALLOWED_HOSTS = computeAllowedHosts(addr.port)
+          const built = createApp()
+          handler = built.app
+          resolve({
+            baseUrl: `http://127.0.0.1:${addr.port}`,
+            close: () => new Promise<void>((r) => server.close(() => r())),
+          })
+        })
+      })
+    }
+
+    test('logs a one-line startup warning when MCP_ALLOWED_HOSTS is not set', () => {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      createApp()
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy.mock.calls[0]?.[0]).toMatch(/MCP_ALLOWED_HOSTS not set/i)
+    })
+
+    test('does not log a warning when MCP_ALLOWED_HOSTS is set', () => {
+      process.env.MCP_ALLOWED_HOSTS = 'mcp.honeyfield.at'
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      createApp()
+
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+
+    test('unset MCP_ALLOWED_HOSTS: initialize still works (unchanged behavior)', async () => {
+      const srv = await startServer()
+      close = srv.close
+
+      const res = await fetch(`${srv.baseUrl}/mcp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+        },
+        body: JSON.stringify(INIT_BODY),
+      })
+      expect(res.status).toBe(200)
+    })
+
+    test('rejects POST /mcp init with a non-allowed Host header', async () => {
+      process.env.MCP_ALLOWED_HOSTS = 'mcp.honeyfield.at'
+      const srv = await startServer()
+      close = srv.close
+
+      const res = await fetch(`${srv.baseUrl}/mcp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+        },
+        body: JSON.stringify(INIT_BODY),
+      })
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.message).toMatch(/host/i)
+      expect(srv.transports.size).toBe(0)
+    })
+
+    test('accepts POST /mcp init with an allowed Host header (exact host:port match)', async () => {
+      const srv = await startServerWithAllowedHost((port) => `127.0.0.1:${port}`)
+      close = srv.close
+
+      const res = await fetch(`${srv.baseUrl}/mcp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+        },
+        body: JSON.stringify(INIT_BODY),
+      })
+
+      expect(res.status).toBe(200)
+      expect(res.headers.get('mcp-session-id')).toBeTruthy()
+    })
+
+    test('rejects when the allowed host omits the port the server listens on (exact match required)', async () => {
+      // Pins down that allowedHosts must match the Host header verbatim, including
+      // the port — this is what makes the README's MCP_ALLOWED_HOSTS=mcp.honeyfield.at
+      // example correct only because production runs on the default HTTPS port (443),
+      // which browsers omit from the Host header.
+      const srv = await startServerWithAllowedHost(() => '127.0.0.1')
+      close = srv.close
+
+      const res = await fetch(`${srv.baseUrl}/mcp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+        },
+        body: JSON.stringify(INIT_BODY),
+      })
+
+      expect(res.status).toBe(403)
+    })
+
+    test('parses comma-separated MCP_ALLOWED_HOSTS entries and trims whitespace', async () => {
+      const srv = await startServerWithAllowedHost((port) => `  example.com , 127.0.0.1:${port}  `)
+      close = srv.close
+
+      const res = await fetch(`${srv.baseUrl}/mcp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+        },
+        body: JSON.stringify(INIT_BODY),
+      })
+
+      expect(res.status).toBe(200)
+    })
+
+    test('rejects a non-allowed Origin header when MCP_ALLOWED_ORIGINS is set', async () => {
+      process.env.MCP_ALLOWED_ORIGINS = 'https://allowed.example'
+      const srv = await startServerWithAllowedHost((port) => `127.0.0.1:${port}`)
+      close = srv.close
+
+      const res = await fetch(`${srv.baseUrl}/mcp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+          Origin: 'https://evil.example',
+        },
+        body: JSON.stringify(INIT_BODY),
+      })
+
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error.message).toMatch(/origin/i)
+    })
+
+    test('accepts a matching Origin header when MCP_ALLOWED_ORIGINS is set', async () => {
+      process.env.MCP_ALLOWED_ORIGINS = 'https://allowed.example'
+      const srv = await startServerWithAllowedHost((port) => `127.0.0.1:${port}`)
+      close = srv.close
+
+      const res = await fetch(`${srv.baseUrl}/mcp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+          Origin: 'https://allowed.example',
+        },
+        body: JSON.stringify(INIT_BODY),
+      })
+
+      expect(res.status).toBe(200)
+    })
   })
 })

--- a/tests/metadata.tool.test.ts
+++ b/tests/metadata.tool.test.ts
@@ -3,12 +3,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // ---------------------------------------------------------------------------
 // Mock CellarClient — must be before importing the tool handler
 // ---------------------------------------------------------------------------
-const mockMetadataQuery = vi.fn()
+const { mockMetadataQuery } = vi.hoisted(() => ({ mockMetadataQuery: vi.fn() }))
 
 vi.mock('../src/services/cellarClient.js', () => ({
-  CellarClient: vi.fn().mockImplementation(() => ({
-    metadataQuery: mockMetadataQuery,
-  })),
+  CellarClient: vi.fn(),
+  sharedCellarClient: { metadataQuery: mockMetadataQuery },
 }))
 
 import { handleEurlexMetadata } from '../src/tools/metadata.js'

--- a/tests/metadata.tool.test.ts
+++ b/tests/metadata.tool.test.ts
@@ -74,17 +74,12 @@ describe('handleEurlexMetadata()', () => {
     expect(result.content[0].text).toContain('SPARQL endpoint unavailable')
   })
 
-  it('M10b – returns isError on invalid CELEX ID', async () => {
-    const result = await handleEurlexMetadata({
-      celex_id: 'INVALID!!!',
-      language: 'DEU',
-    })
-
-    expect(result.isError).toBe(true)
-    expect(result.content).toHaveLength(1)
-    expect(result.content[0].type).toBe('text')
-    expect(result.content[0].text).toMatch(/Error:/)
-  })
+  // Note: handleEurlexMetadata no longer validates celex_id format itself —
+  // the SDK validates via metadataSchema.shape before the handler ever runs
+  // (see registerMetadataTool). That regex behavior is covered at the schema
+  // level in metadataSchema.test.ts (M3, M8); a redundant handler-level
+  // "invalid CELEX" test was removed here since it no longer exercises real
+  // validation logic.
 
   it('M10c – returned JSON contains all MetadataResult fields', async () => {
     mockMetadataQuery.mockResolvedValueOnce(mockResult)

--- a/tests/metadata.tool.test.ts
+++ b/tests/metadata.tool.test.ts
@@ -28,13 +28,14 @@ const mockResult = {
   title: 'AI Act',
   date_document: '2024-06-13',
   date_entry_into_force: '2024-08-01',
-  date_end_of_validity: '',
+  date_end_of_validity: null,
   in_force: true,
-  date_transposition: '',
+  date_transposition: null,
   resource_type: 'REG',
-  authors: ['EP', 'CONSIL'],
+  authors: ['European Parliament', 'Council of the European Union'],
   eurovoc_concepts: ['artificial intelligence', 'high risk'],
-  directory_codes: ['16.40.10'],
+  directory_codes: ['163010: Information technology'],
+  legal_basis: ['12016E114'],
   eurlex_url: 'https://eur-lex.europa.eu/legal-content/de/TXT/?uri=CELEX:32024R1689',
 }
 
@@ -107,10 +108,12 @@ describe('handleEurlexMetadata()', () => {
     expect(parsed).toHaveProperty('authors')
     expect(parsed).toHaveProperty('eurovoc_concepts')
     expect(parsed).toHaveProperty('directory_codes')
+    expect(parsed).toHaveProperty('legal_basis')
     expect(parsed).toHaveProperty('eurlex_url')
 
     expect(Array.isArray(parsed.authors)).toBe(true)
     expect(Array.isArray(parsed.eurovoc_concepts)).toBe(true)
     expect(Array.isArray(parsed.directory_codes)).toBe(true)
+    expect(Array.isArray(parsed.legal_basis)).toBe(true)
   })
 })

--- a/tests/search.tool.test.ts
+++ b/tests/search.tool.test.ts
@@ -66,7 +66,7 @@ describe('handleEurlexSearch()', () => {
     expect(result.isError).toBeFalsy()
   })
 
-  it('query_used matches the SPARQL actually sent to endpoint', async () => {
+  it('T-NOECHO – response does not echo the SPARQL query (query_used dropped)', async () => {
     mockSparqlQuery.mockResolvedValueOnce({
       results: [{ celex: '32024R1689', title: 'AI Act', date: '2024-07-12', type: 'REG', eurlex_url: 'https://example.com' }],
       sparql: 'SELECT DISTINCT ?work ...',
@@ -78,7 +78,8 @@ describe('handleEurlexSearch()', () => {
       limit: 10,
     })
     const parsed = JSON.parse(result.content[0].text)
-    expect(parsed.query_used).toBe('SELECT DISTINCT ?work ...')
+    expect(parsed).not.toHaveProperty('query_used')
+    expect(result.content[0].text).not.toContain('SELECT DISTINCT ?work')
   })
 
   it('T17 – API error returns structured error', async () => {

--- a/tests/search.tool.test.ts
+++ b/tests/search.tool.test.ts
@@ -62,7 +62,7 @@ describe('handleEurlexSearch()', () => {
 
     expect(result.content).toHaveLength(1)
     expect(result.content[0].type).toBe('text')
-    expect(result.content[0].text).toContain('Keine Ergebnisse')
+    expect(result.content[0].text).toContain('No results')
     expect(result.isError).toBeFalsy()
   })
 

--- a/tests/search.tool.test.ts
+++ b/tests/search.tool.test.ts
@@ -4,12 +4,11 @@ import type { SearchResult } from '../src/types.js'
 // ---------------------------------------------------------------------------
 // Mock CellarClient — must be before importing the tool handler
 // ---------------------------------------------------------------------------
-const mockSparqlQuery = vi.fn()
+const { mockSparqlQuery } = vi.hoisted(() => ({ mockSparqlQuery: vi.fn() }))
 
 vi.mock('../src/services/cellarClient.js', () => ({
-  CellarClient: vi.fn().mockImplementation(() => ({
-    sparqlQuery: mockSparqlQuery,
-  })),
+  CellarClient: vi.fn(),
+  sharedCellarClient: { sparqlQuery: mockSparqlQuery },
 }))
 
 import { handleEurlexSearch } from '../src/tools/search.js'

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -76,8 +76,12 @@ describe('Phase 5 – Smoke Tests', () => {
     expect(pair1.server).not.toBe(pair2.server)
   })
 
-  // Annotations: both tools have readOnlyHint: true, destructiveHint: false
-  it('eurlex_search has annotations readOnlyHint=true, destructiveHint=false', async () => {
+  // Annotations: all tools have title, readOnlyHint: true, destructiveHint:
+  // false, idempotentHint: true, openWorldHint: true (Task 5). This exercises
+  // the real McpServer/Client round trip (registerXTool → tools/list), which
+  // is the authoritative way to confirm the SDK actually surfaces `title`
+  // from the annotations object (SDK 1.x supports it — see ToolAnnotations).
+  it('eurlex_search has title, full annotation set, and a self-contained description', async () => {
     const pair = await createTestPair()
     pairs.push(pair)
 
@@ -85,11 +89,16 @@ describe('Phase 5 – Smoke Tests', () => {
     const search = tools.find((t) => t.name === 'eurlex_search')
 
     expect(search?.annotations).toBeDefined()
+    expect(search?.annotations?.title).toBe('Search EU law by title')
     expect(search?.annotations?.readOnlyHint).toBe(true)
     expect(search?.annotations?.destructiveHint).toBe(false)
+    expect(search?.annotations?.idempotentHint).toBe(true)
+    expect(search?.annotations?.openWorldHint).toBe(true)
+    expect(search?.description).toContain('title')
+    expect(search?.description).toContain('eurlex_by_eurovoc')
   })
 
-  it('eurlex_fetch has annotations readOnlyHint=true, destructiveHint=false', async () => {
+  it('eurlex_fetch has title, full annotation set, and a self-contained description', async () => {
     const pair = await createTestPair()
     pairs.push(pair)
 
@@ -97,11 +106,15 @@ describe('Phase 5 – Smoke Tests', () => {
     const fetch = tools.find((t) => t.name === 'eurlex_fetch')
 
     expect(fetch?.annotations).toBeDefined()
+    expect(fetch?.annotations?.title).toBe('Fetch EU legal act full text')
     expect(fetch?.annotations?.readOnlyHint).toBe(true)
     expect(fetch?.annotations?.destructiveHint).toBe(false)
+    expect(fetch?.annotations?.idempotentHint).toBe(true)
+    expect(fetch?.annotations?.openWorldHint).toBe(true)
+    expect(fetch?.description).toContain('offset')
   })
 
-  it('eurlex_metadata has annotations readOnlyHint=true, destructiveHint=false', async () => {
+  it('eurlex_metadata has title, full annotation set, and a self-contained description', async () => {
     const pair = await createTestPair()
     pairs.push(pair)
 
@@ -109,11 +122,16 @@ describe('Phase 5 – Smoke Tests', () => {
     const metadata = tools.find((t) => t.name === 'eurlex_metadata')
 
     expect(metadata?.annotations).toBeDefined()
+    expect(metadata?.annotations?.title).toBe('Get EU legal act metadata')
     expect(metadata?.annotations?.readOnlyHint).toBe(true)
     expect(metadata?.annotations?.destructiveHint).toBe(false)
+    expect(metadata?.annotations?.idempotentHint).toBe(true)
+    expect(metadata?.annotations?.openWorldHint).toBe(true)
+    expect(metadata?.description).toContain('legal basis')
+    expect(metadata?.description).toContain('authors')
   })
 
-  it('eurlex_by_eurovoc has annotations readOnlyHint=true, destructiveHint=false', async () => {
+  it('eurlex_by_eurovoc has title, full annotation set, and a self-contained description', async () => {
     const pair = await createTestPair()
     pairs.push(pair)
 
@@ -121,11 +139,15 @@ describe('Phase 5 – Smoke Tests', () => {
     const eurovoc = tools.find((t) => t.name === 'eurlex_by_eurovoc')
 
     expect(eurovoc?.annotations).toBeDefined()
+    expect(eurovoc?.annotations?.title).toBe('Search EU law by topic')
     expect(eurovoc?.annotations?.readOnlyHint).toBe(true)
     expect(eurovoc?.annotations?.destructiveHint).toBe(false)
+    expect(eurovoc?.annotations?.idempotentHint).toBe(true)
+    expect(eurovoc?.annotations?.openWorldHint).toBe(true)
+    expect(eurovoc?.description).toContain('EuroVoc')
   })
 
-  it('eurlex_citations has annotations readOnlyHint=true, destructiveHint=false', async () => {
+  it('eurlex_citations has title, full annotation set, and a self-contained description', async () => {
     const pair = await createTestPair()
     pairs.push(pair)
 
@@ -133,11 +155,15 @@ describe('Phase 5 – Smoke Tests', () => {
     const citations = tools.find((t) => t.name === 'eurlex_citations')
 
     expect(citations?.annotations).toBeDefined()
+    expect(citations?.annotations?.title).toBe('Find EU legal act citations')
     expect(citations?.annotations?.readOnlyHint).toBe(true)
     expect(citations?.annotations?.destructiveHint).toBe(false)
+    expect(citations?.annotations?.idempotentHint).toBe(true)
+    expect(citations?.annotations?.openWorldHint).toBe(true)
+    expect(citations?.description).toContain('counts')
   })
 
-  it('eurlex_consolidated has annotations readOnlyHint=true, destructiveHint=false', async () => {
+  it('eurlex_consolidated has title, full annotation set, and a self-contained description', async () => {
     const pair = await createTestPair()
     pairs.push(pair)
 
@@ -145,8 +171,12 @@ describe('Phase 5 – Smoke Tests', () => {
     const consolidated = tools.find((t) => t.name === 'eurlex_consolidated')
 
     expect(consolidated?.annotations).toBeDefined()
+    expect(consolidated?.annotations?.title).toBe('Get consolidated EU legal act')
     expect(consolidated?.annotations?.readOnlyHint).toBe(true)
     expect(consolidated?.annotations?.destructiveHint).toBe(false)
+    expect(consolidated?.annotations?.idempotentHint).toBe(true)
+    expect(consolidated?.annotations?.openWorldHint).toBe(true)
+    expect(consolidated?.description).toContain('celex_id')
   })
 
   // V22: eurlex_guide Prompt abrufbar → server has eurlex_guide prompt registered

--- a/tests/ttlCache.test.ts
+++ b/tests/ttlCache.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { TtlCache } from '../src/services/ttlCache.js'
+
+describe('TtlCache', () => {
+  it('TC1 – returns undefined for a key that was never set', () => {
+    const cache = new TtlCache<string>(10, 1000)
+    expect(cache.get('missing')).toBeUndefined()
+  })
+
+  it('TC2 – returns a value that was just set', () => {
+    const cache = new TtlCache<string>(10, 1000)
+    cache.set('a', 'value-a')
+    expect(cache.get('a')).toBe('value-a')
+  })
+
+  it('TC3 – caches a legitimate `null` value distinctly from a cache miss', () => {
+    const cache = new TtlCache<string | null>(10, 1000)
+    cache.set('not-found', null)
+    // A hit that resolves to `null` must be returned as `null`, not `undefined`.
+    expect(cache.get('not-found')).toBeNull()
+    expect(cache.get('not-found')).not.toBeUndefined()
+  })
+
+  it('TC4 – expires an entry once the injected clock reaches expiresAt (now + ttlMs)', () => {
+    let now = 0
+    const clock = (): number => now
+    const cache = new TtlCache<string>(10, 1000, clock)
+
+    cache.set('a', 'value-a')
+
+    now = 999
+    expect(cache.get('a')).toBe('value-a')
+
+    now = 1000
+    expect(cache.get('a')).toBeUndefined()
+  })
+
+  it('TC5 – re-set of an existing key refreshes its TTL', () => {
+    let now = 0
+    const clock = (): number => now
+    const cache = new TtlCache<string>(10, 1000, clock)
+
+    cache.set('a', 'value-a')
+    now = 900
+    cache.set('a', 'value-a-updated')
+    now = 1500 // would be expired relative to the first set, not the second
+    expect(cache.get('a')).toBe('value-a-updated')
+  })
+
+  it('TC6 – evicts the oldest (first-inserted) entry once maxEntries is exceeded (FIFO)', () => {
+    const cache = new TtlCache<string>(2, 100_000)
+    cache.set('a', '1')
+    cache.set('b', '2')
+    cache.set('c', '3') // exceeds maxEntries=2, must evict 'a' (oldest)
+
+    expect(cache.get('a')).toBeUndefined()
+    expect(cache.get('b')).toBe('2')
+    expect(cache.get('c')).toBe('3')
+  })
+
+  it('TC7 – eviction is insertion-order (FIFO), not access-order (LRU)', () => {
+    const cache = new TtlCache<string>(2, 100_000)
+    cache.set('a', '1')
+    cache.set('b', '2')
+    cache.get('a') // touch 'a' — must NOT protect it from FIFO eviction
+    cache.set('c', '3')
+
+    expect(cache.get('a')).toBeUndefined()
+    expect(cache.get('b')).toBe('2')
+    expect(cache.get('c')).toBe('3')
+  })
+
+  it('TC8 – defaults the clock to Date.now when none is injected', () => {
+    const cache = new TtlCache<string>(10, 100_000)
+    cache.set('a', '1')
+    expect(cache.get('a')).toBe('1')
+  })
+
+  it('TC9 – never schedules a timer/interval (expiry is checked on read only)', () => {
+    vi.useFakeTimers()
+    try {
+      const timerCountBefore = vi.getTimerCount()
+      const cache = new TtlCache<string>(10, 1000)
+      cache.set('a', '1')
+      cache.get('a')
+      cache.get('missing')
+      expect(vi.getTimerCount()).toBe(timerCountBefore)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -14,6 +14,53 @@ describe('stripHtml()', () => {
     const result = stripHtml('<div><p>Text</p></div>')
     expect(result).toBe('Text')
   })
+
+  it('decodes &nbsp; and &#160; to a plain space', () => {
+    const result = stripHtml('<p>Article&nbsp;1&#160;Subject</p>')
+    expect(result).toBe('Article 1 Subject')
+  })
+
+  it('decodes &amp;, &lt;, &gt;, &quot;, &#39; and &apos;', () => {
+    const result = stripHtml('<p>Terms &amp; Conditions: &lt;tag&gt; &quot;quoted&quot; it&#39;s &apos;fine&apos;</p>')
+    expect(result).toBe(`Terms & Conditions: <tag> "quoted" it's 'fine'`)
+  })
+
+  it('does not double-decode &amp;lt; into "<"', () => {
+    // &amp;lt; represents the literal text "&lt;", not "<"
+    const result = stripHtml('<p>&amp;lt;</p>')
+    expect(result).toBe('&lt;')
+  })
+
+  it('collapses runs of spaces and tabs into a single space', () => {
+    const result = stripHtml('<p>Article   1\t\tSubject</p>')
+    expect(result).toBe('Article 1 Subject')
+  })
+
+  it('trims trailing spaces at the end of each line', () => {
+    const result = stripHtml('<p>Line one   </p>\n<p>Line two</p>')
+    expect(result).toBe('Line one\nLine two')
+  })
+
+  it('collapses 3+ consecutive newlines to 2', () => {
+    const result = stripHtml('First\n\n\n\n\nSecond')
+    expect(result).toBe('First\n\nSecond')
+  })
+
+  it('leaves a single blank line (2 newlines) alone', () => {
+    const result = stripHtml('First\n\nSecond')
+    expect(result).toBe('First\n\nSecond')
+  })
+
+  it('collapses table-layout blank lines from a table-heavy fixture (no 3+ newline runs remain)', () => {
+    // Simulates an XHTML table where most cells are empty, rendering as long runs
+    // of blank lines once tags are stripped — the live-verified GDPR token-waste finding.
+    const row = (cell: string) => `<tr><td>${cell}</td><td></td><td></td><td></td></tr>\n`
+    const table = `<table>\n${row('Article 1')}${row('')}${row('')}${row('')}${row('Article 2')}</table>`
+    const result = stripHtml(table)
+    expect(result).not.toMatch(/\n{3,}/)
+    expect(result).toContain('Article 1')
+    expect(result).toContain('Article 2')
+  })
 })
 
 describe('toolError()', () => {
@@ -43,29 +90,89 @@ describe('processContent()', () => {
     const result = processContent('<p>Hello</p>', 'xhtml', 1000)
     expect(result.content).toBe('<p>Hello</p>')
     expect(result.truncated).toBe(false)
-    expect(result.charCount).toBe(12)
+    expect(result.total_chars).toBe(12)
+    expect(result.returned_chars).toBe(12)
+    expect(result.offset).toBe(0)
+    expect(result.next_offset).toBeNull()
   })
 
-  it('strips HTML for plain format', () => {
+  it('strips HTML for plain format before measuring/slicing', () => {
     const result = processContent('<p>Hello</p>', 'plain', 1000)
     expect(result.content).toBe('Hello')
-    expect(result.charCount).toBe(5)
+    expect(result.total_chars).toBe(5)
+    expect(result.returned_chars).toBe(5)
   })
 
-  it('truncates and reports original charCount', () => {
+  it('defaults offset to 0 when omitted', () => {
+    const result = processContent('x'.repeat(10), 'xhtml', 5)
+    expect(result.offset).toBe(0)
+    expect(result.content).toBe('xxxxx')
+  })
+
+  it('slices from the start and reports next_offset when truncated', () => {
     const long = 'x'.repeat(5000)
-    const result = processContent(long, 'xhtml', 1000)
+    const result = processContent(long, 'xhtml', 1000, 0)
     expect(result.truncated).toBe(true)
-    expect(result.charCount).toBe(5000)
+    expect(result.total_chars).toBe(5000)
+    expect(result.returned_chars).toBe(1000)
     expect(result.content.length).toBe(1000)
+    expect(result.offset).toBe(0)
+    expect(result.next_offset).toBe(1000)
   })
 
-  it('strips HTML before measuring charCount', () => {
-    const html = '<div>' + 'x'.repeat(100) + '</div>'
-    const result = processContent(html, 'plain', 50)
-    expect(result.charCount).toBe(100) // length after stripping, before truncation
+  it('slices a middle window using a non-zero offset', () => {
+    const text = '0123456789'
+    const result = processContent(text, 'xhtml', 4, 3)
+    expect(result.content).toBe('3456')
+    expect(result.offset).toBe(3)
+    expect(result.returned_chars).toBe(4)
+    expect(result.total_chars).toBe(10)
     expect(result.truncated).toBe(true)
-    expect(result.content.length).toBe(50)
+    expect(result.next_offset).toBe(7)
+  })
+
+  it('reports truncated: false and next_offset: null on the final window', () => {
+    const text = '0123456789'
+    const result = processContent(text, 'xhtml', 4, 6)
+    expect(result.content).toBe('6789')
+    expect(result.returned_chars).toBe(4)
+    expect(result.truncated).toBe(false)
+    expect(result.next_offset).toBeNull()
+  })
+
+  it('returns empty content and truncated: false for an offset beyond the end', () => {
+    const text = '0123456789'
+    const result = processContent(text, 'xhtml', 4, 100)
+    expect(result.content).toBe('')
+    expect(result.returned_chars).toBe(0)
+    expect(result.truncated).toBe(false)
+    expect(result.next_offset).toBeNull()
+    expect(result.total_chars).toBe(10)
+  })
+
+  it('strips HTML before applying the offset window (strip -> slice ordering)', () => {
+    const html = '<div>' + 'x'.repeat(100) + '</div>'
+    const result = processContent(html, 'plain', 50, 10)
+    expect(result.total_chars).toBe(100) // length after stripping, before slicing
+    expect(result.content).toBe('x'.repeat(50))
+    expect(result.truncated).toBe(true)
+    expect(result.next_offset).toBe(60)
+  })
+
+  it('paging through offset=0 then offset=next_offset reconstructs the full processed text', () => {
+    const original = 'The quick brown fox jumps over the lazy dog. '.repeat(50)
+    const maxChars = 137 // deliberately not a clean divisor of the total length
+
+    let cursor = 0
+    let reconstructed = ''
+    for (let guard = 0; guard < 1000; guard++) {
+      const page = processContent(original, 'xhtml', maxChars, cursor)
+      reconstructed += page.content
+      if (!page.truncated) break
+      cursor = page.next_offset as number
+    }
+
+    expect(reconstructed).toBe(original)
   })
 
   it('rejects invalid format at type level', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,15 @@ export default defineConfig({
       reportsDirectory: 'coverage',
       include: ['src/**/*.ts'],
       exclude: ['src/index.ts', 'src/http.ts', 'src/types.ts'],
+      // Floor set ~5 points below the actual run (99.26% stmts/lines, 93.46%
+      // branch, 100% funcs as of 2026-07-03) so a future PR can't silently
+      // erode coverage; not a target to write down to.
+      thresholds: {
+        statements: 94,
+        lines: 94,
+        functions: 95,
+        branches: 88,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

Implements all fixes from the 2026-07-03 four-agent analysis (codebase inventory, platform research, live tool tests, optimization review). 12 commits, executed task-by-task with per-task independent review.

### Reliability (P0)
- **Search timeout fixed** (live-reproduced with "data protection"/"Datenschutz"): removed `ORDER BY` from the search SPARQL (Virtuoso had to materialize all matches before LIMIT); now oversamples (`limit*3`, cap 150) and sorts client-side by date. Actionable timeout error message guides agents to narrow with `resource_type`/date filters.
- **Retry with backoff** (2 retries, 500/1500ms) on all Cellar SPARQL + REST calls — only on network errors/timeouts/5xx, never 4xx.
- **EuroVoc silent failure fixed**: endpoint errors now propagate as tool errors instead of masquerading as "no results".

### Correctness
- **Metadata**: `authors` no longer empty (was querying nonexistent `cdm:agent_name`; now agent `skos:prefLabel` with language→English→URI-tail fallback — live-verified against Cellar), new `legal_basis` field (CELEX IDs), `9999-12-31` sentinel and empty dates → `null`, directory codes now labeled.
- **Citations `direction=both`**: balanced split (ceil/floor of limit per direction, parallel queries) — `cites` results are no longer crowded out by recent `cited_by` entries; new `counts` field.
- **Search type filter**: reported `type` now always matches the filtered `resource_type`.
- **Consolidated lookup**: anchored regex prevents document-number prefix collisions.

### Token efficiency
- Plain-text output: HTML entity decoding + whitespace collapse (GDPR plain text was dominated by table-layout blank lines).
- **Offset pagination** for `eurlex_fetch`/`eurlex_consolidated` (`offset`, `returned_chars`, `total_chars`, `next_offset`) — long acts (AI Act ~500k chars) are now fully paginatable.
- Removed `query_used` (~700 chars of SPARQL echoed in every search response).

### Ergonomics
- All tool descriptions rewritten in English, self-contained (search = title-substring semantics now explicit, pointer to `eurlex_by_eurovoc` for topics), annotations (`title`, `openWorldHint`, `idempotentHint`) added.
- `eurlex_consolidated` now also accepts `celex_id` (XOR with doc_type/year/number).
- `eurlex_consolidated` response includes `consolidated_celex` + `consolidation_date`.

### Performance & security
- TTL caches: EuroVoc label→URI (24h), consolidated CELEX (6h), metadata (6h); shared client instance across tools; errors never cached.
- **Opt-in DNS rebinding protection** via `MCP_ALLOWED_HOSTS`/`MCP_ALLOWED_ORIGINS` — strictly opt-in, so the current deployment keeps working; production should set `MCP_ALLOWED_HOSTS=mcp.honeyfield.at` (see README, note the reverse-proxy Host-forwarding requirement).

### Housekeeping
- Coverage thresholds added (94/88/95 vs. current 99.3/93.5/100).
- Fixed pre-existing eval-suite breakage (`createServer` import) — `pnpm run test:integration` deterministic parts now pass.

## Breaking changes (MCP response fields)
- `char_count` → `returned_chars`/`total_chars` (fetch/consolidated)
- `query_used` removed (search)
- Metadata date fields now `string | null`; `authors`/`directory_codes` content changed
- Tool descriptions now English

## Test plan
- 335/335 unit tests green, `pnpm run check` clean (typecheck, lint, format, tests), coverage 99.26% stmts.
- Live-verified during development: metadata CDM properties probed against Cellar (GDPR + AI Act); scoped live integration tests pass.
- Each task independently reviewed (spec + quality) + final whole-branch review (verdict: ready to merge, no Critical/Important findings).
- Not covered: end-to-end verification against the deployed instance (requires deploy).

https://claude.ai/code/session_01Povn24SYPnf34sxZ5qky37