### PR TITLE
fix: content-negotiation fallback and 202/empty-body handling in eurlex_fetch

### DIFF
--- a/src/services/cellarClient.ts
+++ b/src/services/cellarClient.ts
@@ -205,6 +205,19 @@ class HttpStatusError extends Error {
   }
 }
 
+/**
+ * Error for a Cellar response that succeeded at the HTTP level (2xx) but carries
+ * no usable body — an empty/whitespace-only document, which Cellar returns while
+ * a rendition is still being generated. Retryable like an HTTP 202: returning it
+ * as a successful empty document would give downstream callers no failure signal.
+ */
+class EmptyBodyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EmptyBodyError';
+  }
+}
+
 /** True for DOMException/Error-like objects representing an aborted/timed-out request. */
 function isTimeoutError(error: unknown): boolean {
   return (
@@ -217,12 +230,16 @@ function isTimeoutError(error: unknown): boolean {
 
 /**
  * Decides whether a failure from executeSparql/fetchCellarDocument should be retried:
- * network errors (TypeError from fetch), timeouts (AbortError/TimeoutError), and
- * HTTP 5xx. Never 4xx or other errors.
+ * network errors (TypeError from fetch), timeouts (AbortError/TimeoutError), HTTP 5xx,
+ * HTTP 202 (rendition still generating), and an empty Cellar body (same cause).
+ * Never 4xx or other errors.
  */
 function isRetryableError(error: unknown): boolean {
   if (error instanceof HttpStatusError) {
-    return error.status >= 500;
+    return error.status >= 500 || error.status === 202;
+  }
+  if (error instanceof EmptyBodyError) {
+    return true;
   }
   if (error instanceof TypeError) {
     return true;
@@ -459,7 +476,11 @@ export class CellarClient {
       const response = await fetch(url, {
         method: 'GET',
         headers: {
-          Accept: 'application/xhtml+xml',
+          // Prefer XHTML but accept legacy HTML: many older documents (most CJEU
+          // case law) hold only a text/html datastream, and Cellar 404s a
+          // single-type xhtml request against them. Cellar honours the preference
+          // order, still serving XHTML where it exists.
+          Accept: 'application/xhtml+xml, text/html',
           'Accept-Language': httpLang,
         },
         redirect: 'follow',
@@ -474,11 +495,29 @@ export class CellarClient {
         throw new HttpStatusError(context.notAcceptableError, 406);
       }
 
+      // 202 Accepted: Cellar is still generating the rendition (ok===true, so this
+      // must precede the response.ok check). Retryable — surfacing the placeholder
+      // body as success would give downstream callers no signal to fall back.
+      if (response.status === 202) {
+        throw new HttpStatusError(
+          'Cellar is still generating this document rendition (HTTP 202). Retry in a few seconds.',
+          202,
+        );
+      }
+
       if (!response.ok) {
         throw new HttpStatusError(`Fetch error: ${response.status}`, response.status);
       }
 
-      return response.text();
+      const body = await response.text();
+      // Never return an empty/whitespace-only body as a successful document: a 2xx
+      // with a blank body is Cellar mid-render (see EmptyBodyError). Retryable.
+      if (body.trim() === '') {
+        throw new EmptyBodyError(
+          'Cellar returned an empty document body. The rendition may still be generating — retry in a few seconds.',
+        );
+      }
+      return body;
     });
   }
 
@@ -488,7 +527,7 @@ export class CellarClient {
    */
   async fetchDocument(celex_id: string, language: string): Promise<string> {
     return this.fetchCellarDocument(celex_id, language, {
-      notFoundError: `Document not found: ${celex_id}. The document may not be available in electronic full-text format on EUR-Lex.`,
+      notFoundError: `Document not found: ${celex_id}. Cellar holds no XHTML or HTML rendition for it — the document may be PDF-only on EUR-Lex, or the CELEX ID may be wrong.`,
       notAcceptableError: `Document ${celex_id} is not available in XHTML format. Older documents may only exist as PDF on EUR-Lex.`,
     });
   }

--- a/tests/cellarClient.consolidated.test.ts
+++ b/tests/cellarClient.consolidated.test.ts
@@ -62,7 +62,7 @@ describe('fetchConsolidated()', () => {
     // Second call should be Cellar REST with the consolidated CELEX
     const [url2, opts2] = mockFetch.mock.calls[1] as [string, RequestInit]
     expect(url2).toContain('publications.europa.eu/resource/celex/02024R1689-20240712')
-    expect((opts2.headers as Record<string, string>).Accept).toBe('application/xhtml+xml')
+    expect((opts2.headers as Record<string, string>).Accept).toBe('application/xhtml+xml, text/html')
     expect((opts2.headers as Record<string, string>)['Accept-Language']).toBe('de')
   })
 

--- a/tests/cellarClient.retry.test.ts
+++ b/tests/cellarClient.retry.test.ts
@@ -35,6 +35,11 @@ function rest5xx(status = 503) {
   return { ok: false, status, statusText: 'Service Unavailable' }
 }
 
+/** HTTP 202: Cellar is still generating the rendition (ok===true, placeholder body). */
+function rest202() {
+  return { ok: true, status: 202, text: async () => '' }
+}
+
 // ===========================================================================
 // executeSparql retry behaviour (exercised via sparqlQuery)
 // ===========================================================================
@@ -161,6 +166,70 @@ describe('fetchDocument() via shared fetchCellarDocument() helper — retry', ()
     expect(result).toBe('<html>ok</html>')
     expect(mockFetch).toHaveBeenCalledTimes(2)
     expect(delayFn).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ===========================================================================
+// fetchCellarDocument — issue #30: HTTP 202 (rendition still generating) and
+// empty-body handling. Neither may surface as a successful empty document.
+// ===========================================================================
+describe('fetchDocument() — rendition-pending (202) and empty-body guard', () => {
+  it('retries on 202 (rendition generating) then succeeds once it is ready', async () => {
+    const { client, delayFn } = makeClientWithFakeDelay()
+    mockFetch.mockResolvedValueOnce(rest202()).mockResolvedValueOnce(restOk('<html>ready</html>'))
+
+    const result = await client.fetchDocument('62021CJ0607', 'ENG')
+
+    expect(result).toBe('<html>ready</html>')
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(delayFn).toHaveBeenCalledTimes(1)
+    expect(delayFn).toHaveBeenCalledWith(500)
+  })
+
+  it('rejects with a "still generating / retry" error when 202 persists (never empty success)', async () => {
+    const { client, delayFn } = makeClientWithFakeDelay()
+    mockFetch
+      .mockResolvedValueOnce(rest202())
+      .mockResolvedValueOnce(rest202())
+      .mockResolvedValueOnce(rest202())
+
+    await expect(client.fetchDocument('62021CJ0488', 'ENG')).rejects.toThrow(
+      /still generating.*retry/i,
+    )
+
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+    expect(delayFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects on an empty body instead of resolving with "" (retries first)', async () => {
+    const { client } = makeClientWithFakeDelay()
+    mockFetch.mockResolvedValue(restOk(''))
+
+    await expect(client.fetchDocument('62021CJ0488', 'ENG')).rejects.toThrow(
+      /empty document body.*retry/i,
+    )
+
+    // Empty body is retryable: 3 total attempts, then a loud error (not "").
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+  })
+
+  it('rejects on a whitespace-only body (treated as empty)', async () => {
+    const { client } = makeClientWithFakeDelay()
+    mockFetch.mockResolvedValue(restOk('   \n\t  '))
+
+    await expect(client.fetchDocument('62021CJ0488', 'ENG')).rejects.toThrow(/empty document body/i)
+
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+  })
+
+  it('sends Accept: "application/xhtml+xml, text/html" (xhtml preferred, html fallback)', async () => {
+    const { client } = makeClientWithFakeDelay()
+    mockFetch.mockResolvedValueOnce(restOk('<html>ok</html>'))
+
+    await client.fetchDocument('62005CJ0001', 'ENG')
+
+    const [, init] = mockFetch.mock.calls[0]
+    expect(init.headers.Accept).toBe('application/xhtml+xml, text/html')
   })
 })
 

--- a/tests/cellarClient.test.ts
+++ b/tests/cellarClient.test.ts
@@ -139,7 +139,7 @@ describe('fetchDocument()', () => {
     })
 
     const client = new CellarClient()
-    await expect(client.fetchDocument('00000X0000', 'DEU')).rejects.toThrow('Document not found: 00000X0000. The document may not be available in electronic full-text format on EUR-Lex.')
+    await expect(client.fetchDocument('00000X0000', 'DEU')).rejects.toThrow('Document not found: 00000X0000. Cellar holds no XHTML or HTML rendition for it — the document may be PDF-only on EUR-Lex, or the CELEX ID may be wrong.')
   })
 
   it('T8 – uses Cellar REST URL with content negotiation headers', async () => {
@@ -157,7 +157,7 @@ describe('fetchDocument()', () => {
     expect(url).toBe('https://publications.europa.eu/resource/celex/32021R0694')
 
     const headers = options.headers as Record<string, string>
-    expect(headers['Accept']).toBe('application/xhtml+xml')
+    expect(headers['Accept']).toBe('application/xhtml+xml, text/html')
     expect(headers['Accept-Language']).toBe('en')
   })
 
@@ -313,7 +313,7 @@ describe('fetchDocument() – old/unavailable documents', () => {
       .rejects.toThrow('Document 31995L0046 is not available in XHTML format. Older documents may only exist as PDF on EUR-Lex.')
   })
 
-  it('T14f – 404 error message includes hint about electronic format', async () => {
+  it('T14f – 404 error message includes hint about missing renditions', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 404,
@@ -322,7 +322,7 @@ describe('fetchDocument() – old/unavailable documents', () => {
 
     const client = new CellarClient()
     await expect(client.fetchDocument('31995L0046', 'DEU'))
-      .rejects.toThrow('The document may not be available in electronic full-text format on EUR-Lex.')
+      .rejects.toThrow('Cellar holds no XHTML or HTML rendition for it — the document may be PDF-only on EUR-Lex, or the CELEX ID may be wrong.')
   })
 })
 

--- a/tests/eval/phase5-validation.eval.test.ts
+++ b/tests/eval/phase5-validation.eval.test.ts
@@ -179,7 +179,7 @@ describe('Phase 5 Eval – Validation Matrix', () => {
       const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit]
       expect(url).toContain('publications.europa.eu/resource/celex')
       const headers = options.headers as Record<string, string>
-      expect(headers['Accept']).toBe('application/xhtml+xml')
+      expect(headers['Accept']).toBe('application/xhtml+xml, text/html')
     })
 
     it('V11: fetchDocument DEU sets Accept-Language: de', async () => {


### PR DESCRIPTION
## Summary

Fixes both failure modes reported in #30 (verified live against Cellar on 2026-07-05 — both still present in v2.1.0).

### Bug 1 — `"Document not found"` for existing judgments (root cause)

`fetchCellarDocument` sent a single hard-coded `Accept: application/xhtml+xml`. Most CJEU case law (including `62005CJ0001` / *Jia* and — it turns out — `62021CJ0607` from the "bug 2" list) holds **only a legacy `text/html` datastream** in Cellar, which then answers `404 "does not hold a content datastream of the requested type"`. A live probe of six recent (2026) judgments showed 4 of 6 are html-only, so this was systematic for sector 6, not an edge case.

**Fix:** `Accept: application/xhtml+xml, text/html`. Wire-verified: Cellar honours the preference order — still serves XHTML where the datastream exists, falls back to html otherwise.

### Bug 2 — silent empty success on HTTP 202 (defense-in-depth)

HTTP 202 ("rendition being generated") has `response.ok === true`, so its placeholder body flowed through `processContent` (no empty guard) into a *successful* `{content: "", total_chars: 0, truncated: false}` result.

**Fix:** explicit 202 branch throwing a retryable `HttpStatusError` (re-attempted via the existing `withRetry` backoff, then surfaced as a distinct "still generating — retry" error), plus an empty/whitespace-body guard (`EmptyBodyError`, also retryable). An empty body can never surface as success anymore. Note: 202 was not reproducible on the live endpoint anymore (Cellar appears to render synchronously now, probed across fresh judgments, fresh acts, and never-requested consolidated renditions) — this path is covered by unit tests with mocked `fetch`.

The shared helper means `eurlex_consolidated` and `eurlex_summary` get the same fix. The 404 message was also reworded to stop conflating "does not exist" with "no XHTML/HTML rendition".

## Verification

- **TDD:** 5 new unit tests in `tests/cellarClient.retry.test.ts` written first and confirmed failing against the old code (e.g. `promise resolved "''" instead of rejecting`), green after the fix.
- **`pnpm run check`** exit 0 — 650 tests / 49 files, coverage floor holds.
- **Live e2e** through the full tool path (`handleEurlexFetch`, formats `plain` + `xhtml`): `62005CJ0001` → 32k chars plain text ("Case C-1/05 Yunying Jia v Migrationsverket…"), `62021CJ0607` → 49k chars, `62021CJ0488` → 45k chars; control fetch `32024R1689` (AI Act) unaffected. `format: 'plain'` correctly strips the legacy uppercase `<HTML>` markup.

Closes #30

https://claude.ai/code/session_01Povn24SYPnf34sxZ5qky37