### PR TITLE
chore(release): v2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eurlex-mcp-server",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "MCP Server for EU law via EUR-Lex Cellar API — search, fetch, and analyze EU regulations, directives, and court decisions",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Patch release: `eurlex_fetch` content-negotiation fallback (`Accept: application/xhtml+xml, text/html`) and 202/empty-body handling for Cellar document retrieval (#30, fixed in #36).

After merge: tag `v2.1.1` on the merge commit → release.yml publishes to npm (OIDC), builds/pushes the Docker image to ECR, and deploys the gateway with live version verify.

https://claude.ai/code/session_01Povn24SYPnf34sxZ5qky37