### PR TITLE
chore(release): v2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eurlex-mcp-server",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "MCP Server for EU law via EUR-Lex Cellar API — search, fetch, and analyze EU regulations, directives, and court decisions",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Version bump `2.1.1` → `2.2.0` (minor — new feature).

### Since v2.1.1 (#38)
- **feat(structure): detect CJEU judgment paragraphs** — `eurlex_structure` now lists each numbered paragraph of a CJEU judgment (CELEX sector 6) as `Paragraph N` with a plain-text `offset`, so `eurlex_fetch(offset)` jumps straight to it (Refs #29).
- **refactor:** centralize `max_chars` bounds in `constants.ts`.

Merging this and pushing the `v2.2.0` tag drives `release.yml` (GitHub Release + npm publish via OIDC + Docker → ECR → gateway deploy, verified).

https://claude.ai/code/session_01NMJue1G4xW35wDzodHCAKC
